### PR TITLE
Copy instead of build

### DIFF
--- a/src-opam/dockerfile_distro.ml
+++ b/src-opam/dockerfile_distro.ml
@@ -20,7 +20,7 @@ open Dockerfile
 open Dockerfile_opam
 module Linux = Dockerfile_linux
 
-type t = [ 
+type t = [
   | `Alpine of [ `V3_3 | `V3_4 | `V3_5 | `V3_6 | `Latest ]
   | `CentOS of [ `V6 | `V7 ]
   | `Debian of [ `V10 | `V9 | `V8 | `V7 | `Stable | `Testing | `Unstable ]
@@ -276,7 +276,7 @@ let apk_opam ?pin ?opam_version ?compiler_version ~os_version labels tag =
 
 (* Zypper (OpenSUSE) Dockerfile *)
 let zypper_opam ?pin ?opam_version ?compiler_version labels tag =
-  let branch, need_upgrade, install_wrappers = opam2_test opam_version in 
+  let branch, need_upgrade, install_wrappers = opam2_test opam_version in
   add_comment ?compiler_version tag @@
   header "ocaml/ocaml" tag @@
   label (("distro_style", "zypper")::labels) @@
@@ -355,7 +355,7 @@ let latest_dockerfile_matrix ?(opam_version=latest_opam_version) ?(extra=[]) ?pi
   List.map (fun distro ->
     distro,
     to_dockerfile ?pin ~opam_version ~ocaml_version:latest_ocaml_version ~distro ()
-  ) (latest_stable_distros @ extra) |> 
+  ) (latest_stable_distros @ extra) |>
   List.sort (fun (a,_) (b,_) -> compare a b)
 
 let map_tag ?filter fn =

--- a/src-opam/dockerfile_distro.ml
+++ b/src-opam/dockerfile_distro.ml
@@ -229,7 +229,7 @@ let apt_opam ?pin ?opam_version ?compiler_version labels distro tag =
     Linux.Git.init () @@
     opam_init ?compiler_version ~need_upgrade () @@
     (match pin with Some x -> run_as_opam "opam pin add %s" x | None -> empty) @@
-    run_as_opam "opam install -y depext travis-opam" @@
+    Dockerfile.copy ~from:"ocaml/ci-opam" ~src:["/ci-opam"] ~dst:"/usr/bin" () @@
     entrypoint_exec ["opam";"config";"exec";"--"] @@
     cmd_exec ["bash"]
 


### PR DESCRIPTION
The ocaml/ci-opam image has to be manually pushed by using the script added in https://github.com/ocaml/ocaml-ci-scripts/pull/183

The good thing about this change remove all the build/packaging constraints that we had on ocaml-ci-scripts (e.g. simple build system, no dependency, etc) as this is now a static binary which is copied. The bad part is that it's a bit harder to update the binary with a custom `ci-opam` (e.g. `FORK_USER` and `FORK_BRANCH` will not work anymore). I think that's fine but feedback appreciated.