### PR TITLE
Fix and use Dockerfile_linux.*.dev_packages internally

### DIFF
--- a/src-opam/dockerfile_linux.ml
+++ b/src-opam/dockerfile_linux.ml
@@ -57,7 +57,8 @@ module RPM = struct
     run "chmod 700 .ssh"
 
   let dev_packages ?extra () =
-    install "sudo passwd bzip2 patch nano gcc-c++ git%s" (match extra with None -> "" | Some x -> " " ^ x) @@
+    install "sudo passwd bzip2 patch nano gcc-c++ git tar curl xz libX11-devel which%s"
+      (match extra with None -> "" | Some x -> " " ^ x) @@
     groupinstall "\"Development Tools\""
 
   let install_system_ocaml =
@@ -72,7 +73,7 @@ module Apt = struct
   let dev_packages ?extra () =
     update @@
     run "echo 'Acquire::Retries \"5\";' > /etc/apt/apt.conf.d/mirror-retry" @@
-    install "sudo pkg-config git build-essential m4 software-properties-common aspcud unzip rsync curl dialog nano libx11-dev%s"
+    install "build-essential curl git rsync sudo unzip nano libx11-dev%s"
       (match extra with None -> "" | Some x -> " " ^ x)
 
   let add_user ?uid ?gid ?(sudo=false) username =
@@ -106,7 +107,7 @@ module Apk = struct
   let install fmt = ksprintf (fun s -> update @@ run "apk add %s" s) fmt
 
   let dev_packages ?extra () =
-    install "alpine-sdk openssh bash nano ncurses-dev %s"
+    install "build-base tar ca-certificates git rsync curl sudo bash libx11-dev nano ncurses-dev%s"
       (match extra with None -> "" | Some x -> " " ^ x)
 
   let add_user ?uid ?gid ?(sudo=false) username =
@@ -139,7 +140,7 @@ module Zypper = struct
 
   let dev_packages ?extra () =
     install "-t pattern devel_C_C++" @@
-    install "sudo git unzip curl gcc-c++" @@
+    install "sudo git unzip curl gcc-c++ libX11-devel" @@
     (maybe (install "%s") extra)
 
   let add_user ?uid ?gid ?(sudo=false) username =

--- a/src-opam/dockerfile_linux.ml
+++ b/src-opam/dockerfile_linux.ml
@@ -107,7 +107,7 @@ module Apk = struct
   let install fmt = ksprintf (fun s -> update @@ run "apk add %s" s) fmt
 
   let dev_packages ?extra () =
-    install "build-base tar ca-certificates git rsync curl sudo bash libx11-dev nano ncurses-dev%s"
+    install "build-base patch tar ca-certificates git rsync curl sudo bash libx11-dev nano ncurses-dev%s"
       (match extra with None -> "" | Some x -> " " ^ x)
 
   let add_user ?uid ?gid ?(sudo=false) username =

--- a/src-opam/dockerfile_linux.mli
+++ b/src-opam/dockerfile_linux.mli
@@ -82,8 +82,8 @@ module Apk : sig
   (** [install fmt] will [apk add] the packages specified by the [fmt] format string. *)
 
   val dev_packages : ?extra:string -> unit -> t
-  (** [dev_packages ?extra ()] will install the base alpine-sdk.
-      Extra packages may also be optionally supplied via [extra]. *)
+  (** [dev_packages ?extra ()] will install the base development tools and [sudo],
+      [passwd] and [git].  Extra packages may also be optionally supplied via [extra]. *)
 
   val add_user : ?uid:int -> ?gid:int -> ?sudo:bool -> string -> t
   (** [add_user username] will install a new user with name [username] and a locked

--- a/src-opam/dockerfile_opam.ml
+++ b/src-opam/dockerfile_opam.ml
@@ -64,8 +64,7 @@ let apk_opam2 ?(labels= []) ~distro ~tag () =
   @@ copy ~from:"0" ~src:["/usr/local/bin/opam"] ~dst:"/usr/bin/opam" ()
   @@ copy ~from:"0" ~src:["/usr/local/bin/opam-installer"]
        ~dst:"/usr/bin/opam-installer" ()
-  @@ Linux.Apk.install
-       "build-base tar ca-certificates git rsync curl sudo bash"
+  @@ Linux.Apk.dev_packages ()
   @@ Linux.Apk.add_user ~uid:1000 ~sudo:true "opam" @@ Linux.Git.init ()
   @@ run
        "git clone git://github.com/ocaml/opam-repository /home/opam/opam-repository"
@@ -80,7 +79,7 @@ let apt_opam2 ?(labels= []) ~distro ~tag () =
   @@ copy ~from:"0" ~src:["/usr/local/bin/opam"] ~dst:"/usr/bin/opam" ()
   @@ copy ~from:"0" ~src:["/usr/local/bin/opam-installer"]
        ~dst:"/usr/bin/opam-installer" ()
-  @@ Linux.Apt.install "build-essential curl git rsync sudo unzip"
+  @@ Linux.Apt.dev_packages ()
   @@ Linux.Apt.add_user ~uid:1000 ~sudo:true "opam" @@ Linux.Git.init ()
   @@ run
        "git clone git://github.com/ocaml/opam-repository /home/opam/opam-repository"
@@ -103,11 +102,11 @@ let yum_opam2 ?(labels= []) ~distro ~tag () =
   in
   header distro tag @@ label (("distro_style", "apt") :: labels)
   @@ Linux.RPM.update @@ centos6_modern_git
-  @@ Linux.RPM.dev_packages ~extra:"which tar curl xz" ()
+  @@ Linux.RPM.dev_packages ()
   @@ install_opam_from_source ~prefix:"/usr" ~install_wrappers:true
        ~branch:"master" ()
   @@ from ~tag distro @@ Linux.RPM.update
-  @@ Linux.RPM.dev_packages ~extra:"which tar curl xz" ()
+  @@ Linux.RPM.dev_packages ()
   @@ copy ~from:"0" ~src:["/usr/bin/opam"] ~dst:"/usr/bin/opam" ()
   @@ copy ~from:"0" ~src:["/usr/bin/opam-installer"]
        ~dst:"/usr/bin/opam-installer" ()
@@ -124,7 +123,8 @@ let zypper_opam2 ?(labels= []) ~distro ~tag () =
   @@ Linux.Zypper.dev_packages ()
   @@ install_opam_from_source ~prefix:"/usr" ~install_wrappers:true
        ~branch:"master" ()
-  @@ from ~tag distro @@ Linux.Zypper.dev_packages ()
+  @@ from ~tag distro
+  @@ Linux.Zypper.dev_packages ()
   @@ copy ~from:"0" ~src:["/usr/bin/opam"] ~dst:"/usr/bin/opam" ()
   @@ copy ~from:"0" ~src:["/usr/bin/opam-installer"]
        ~dst:"/usr/bin/opam-installer" ()
@@ -281,4 +281,3 @@ let multiarch_manifest ~target ~platforms =
     |> String.concat "\n"
   in
   Fmt.strf "image: %s\nmanifests:\n%s" target ms
-


### PR DESCRIPTION
This fixes the lack of ```Graphics``` module in the ```ocaml/opam2``` images.
It also uses an halfish-unused functions that could have fix the issue in the first place.

I'll be testing the result of those changes during the night on the ARM64 machine.

See log output of https://github.com/ocaml/opam-repository/pull/11504 and several others for the original issue with ```Graphics```.