### PR TITLE
Create opam group on all platforms

### DIFF
--- a/src-opam/dockerfile_linux.ml
+++ b/src-opam/dockerfile_linux.ml
@@ -145,7 +145,7 @@ module Zypper = struct
 
   let add_user ?uid ?gid ?(sudo=false) username =
     let home = "/home/"^username in
-    run "useradd %s%s -d %s -m %s"
+    run "useradd %s%s -d %s -m --user-group %s"
       (match uid with None -> "" | Some d -> sprintf "-u %d " d)
       (match gid with None -> "" | Some g -> sprintf "-g %d " g)
       home username @@

--- a/src-opam/dockerfile_opam.ml
+++ b/src-opam/dockerfile_opam.ml
@@ -81,8 +81,9 @@ let apk_opam2 ?(labels= []) ~distro ~tag () =
   @@ copy ~from:"0" ~src:["/usr/local/bin/opam"] ~dst:"/usr/bin/opam" ()
   @@ copy ~from:"0" ~src:["/usr/local/bin/opam-installer"]
        ~dst:"/usr/bin/opam-installer" ()
+  @@ run "addgroup opam"
   @@ Linux.Apk.dev_packages ()
-  @@ Linux.Apk.add_user ~uid:1000 ~sudo:true "opam"
+  @@ Linux.Apk.add_user ~uid:1000 ~gid:1000 ~sudo:true "opam"
   @@ install_bubblewrap_wrappers @@ Linux.Git.init ()
   @@ run
        "git clone git://github.com/ocaml/opam-repository /home/opam/opam-repository"


### PR DESCRIPTION
This allows `COPY --chown=opam` (which Docker interprets as `COPY --chown=opam:opam`) to work everywhere.