### PR TITLE
Add the Alpine testing repository

### DIFF
--- a/src-opam/dockerfile_linux.ml
+++ b/src-opam/dockerfile_linux.ml
@@ -131,6 +131,11 @@ module Apk = struct
 
   let install_system_ocaml =
     run "apk add ocaml camlp4"
+
+  let add_repository ?tag url =
+    match tag with
+    | None -> run "echo '%s' >> /etc/apk/repositories" url
+    | Some tag -> run "echo '@%s %s' >> /etc/apk/repositories" tag url
 end
 
 (* Zypper (opensuse) rules *)

--- a/src-opam/dockerfile_linux.mli
+++ b/src-opam/dockerfile_linux.mli
@@ -92,6 +92,9 @@ module Apk : sig
 
   val install_system_ocaml : t
   (** Install the system OCaml packages via Apk *)
+
+  val add_repository : ?tag:string -> string -> t
+  (** [add_repository ~tag url] adds "@tag url" to "/etc/apk/repositories". *)
 end
 
 (** Rules for Zypper-based distributions such as OpenSUSE *)

--- a/src-opam/dockerfile_opam.ml
+++ b/src-opam/dockerfile_opam.ml
@@ -78,6 +78,7 @@ let apk_opam2 ?(labels= []) ~distro ~tag () =
   @@ install_opam_from_source ~branch:"2.0" ()
   @@ run "strip /usr/local/bin/opam*"
   @@ from ~tag distro
+  @@ Linux.Apk.add_repository ~tag:"testing" "http://dl-cdn.alpinelinux.org/alpine/edge/testing"
   @@ copy ~from:"0" ~src:["/usr/local/bin/opam"] ~dst:"/usr/bin/opam" ()
   @@ copy ~from:"0" ~src:["/usr/local/bin/opam-installer"]
        ~dst:"/usr/bin/opam-installer" ()


### PR DESCRIPTION
This allows opam depexts to refer to testing packages with e.g.

    ["capnproto-dev@testing"] {os-distribution = "alpine"}