### PR TITLE
Make the curl step fail if the download fails

### DIFF
--- a/src-opam/dockerfile_opam.ml
+++ b/src-opam/dockerfile_opam.ml
@@ -35,7 +35,7 @@ let install_bubblewrap_from_source ?(prefix="/usr/local") () =
   let rel = "0.3.1" in
   let file = Fmt.strf "bubblewrap-%s.tar.xz" rel in
   let url = Fmt.strf "https://github.com/projectatomic/bubblewrap/releases/download/v%s/bubblewrap-%s.tar.xz" rel rel in
-  run "curl -OL %s" url @@
+  run "curl -fOL %s" url @@
   run "tar xf %s" file @@
   run "cd bubblewrap-%s && ./configure --prefix=%s && make && sudo make install" rel prefix @@
   run "rm -rf %s bubblewrap-%s" file rel


### PR DESCRIPTION
Otherwise, the download step succeeds but the tar step fails. Since the curl step succeeded, retrying just uses the cached version again.

    Step 6/56 : RUN curl -OL https://github.com/projectatomic/bubblewrap/releases/download/v0.3.1/bubblewrap-0.3.1.tar.xz
    Step 7/56 : RUN tar xf bubblewrap-0.3.1.tar.xz
    tar: This does not look like a tar archive