### PR TITLE
Build PPC images for Ubuntu

### DIFF
--- a/src-opam/dockerfile_distro.ml
+++ b/src-opam/dockerfile_distro.ml
@@ -70,8 +70,8 @@ let distro_status (d:t) : status = match d with
   | `OpenSUSE (`V42_1 | `V42_2 | `V42_3 | `V15_0) -> `Deprecated
   | `OpenSUSE `V15_1 -> `Active `Tier2
   | `OpenSUSE `Latest -> `Alias (`OpenSUSE `V15_1)
-  | `Ubuntu (`V16_04 | `V18_04 | `V19_10 | `V20_04) -> `Active `Tier2
-  | `Ubuntu ( `V12_04 | `V14_04 | `V15_04 | `V15_10 | `V16_10 | `V17_04 | `V17_10 | `V18_10 | `V19_04) -> `Deprecated
+  | `Ubuntu (`V16_04 | `V18_04 | `V20_04) -> `Active `Tier2
+  | `Ubuntu ( `V12_04 | `V14_04 | `V15_04 | `V15_10 | `V16_10 | `V17_04 | `V17_10 | `V18_10 | `V19_04 | `V19_10 ) -> `Deprecated
   | `Ubuntu `LTS -> `Alias (`Ubuntu `V18_04)
   | `Ubuntu `Latest -> `Alias (`Ubuntu `V19_10)
 

--- a/src-opam/dockerfile_distro.ml
+++ b/src-opam/dockerfile_distro.ml
@@ -93,7 +93,7 @@ let distro_arches ov (d:t) =
   match resolve_alias d, ov with
   | `Debian (`V9|`V10), ov when OV.(compare Releases.v4_05_0 ov) = -1 -> [ `I386; `X86_64; `Aarch64; `Ppc64le; `Aarch32 ]
   | `Alpine (`V3_6 | `V3_7 | `V3_8 | `V3_9 | `V3_10 | `V3_11 | `V3_12), ov when OV.(compare Releases.v4_05_0 ov) = -1 -> [ `X86_64; `Aarch64 ]
-  | `Ubuntu (`V16_04|`V18_04|`V17_10|`V18_10|`V19_04|`V19_10|`V20_04), ov when OV.(compare Releases.v4_05_0 ov) = -1  -> [ `X86_64; `Aarch64 ]
+  | `Ubuntu (`V18_04|`V20_04), ov when OV.(compare Releases.v4_05_0 ov) = -1  -> [ `X86_64; `Aarch64; `Ppc64le ]
   | _ -> [ `X86_64 ]
 
 


### PR DESCRIPTION
This is useful for OCluster, because Ubuntu has the most up-to-date Docker packages.

Also, removed some obsolete versions from the list.