### PR TITLE
Add support for archlinux

### DIFF
--- a/src-opam/dockerfile_distro.ml
+++ b/src-opam/dockerfile_distro.ml
@@ -20,6 +20,7 @@ open Astring
 
 type t = [
   | `Alpine of [ `V3_3 | `V3_4 | `V3_5 | `V3_6 | `V3_7 | `V3_8 | `V3_9 | `V3_10 | `V3_11 | `V3_12 | `Latest ]
+  | `Archlinux of [ `Latest ]
   | `CentOS of [ `V6 | `V7 | `V8 | `Latest ]
   | `Debian of [ `V10 | `V9 | `V8 | `V7 | `Stable | `Testing | `Unstable ]
   | `Fedora of [ `V21 | `V22 | `V23 | `V24 | `V25 | `V26 | `V27 | `V28 | `V29 | `V30 | `V31 | `V32 | `Latest ]
@@ -36,6 +37,7 @@ type status = [
 
 let distros = [
   `Alpine `V3_3; `Alpine `V3_4; `Alpine `V3_5; `Alpine `V3_6; `Alpine `V3_7; `Alpine `V3_8; `Alpine `V3_9; `Alpine `V3_10; `Alpine `V3_11; `Alpine `V3_12; `Alpine `Latest;
+  `Archlinux `Latest;
   `CentOS `V6; `CentOS `V7; `CentOS `V8; `CentOS `Latest;
   `Debian `V10; `Debian `V9; `Debian `V8; `Debian `V7;
   `Debian `Stable; `Debian `Testing; `Debian `Unstable;
@@ -51,12 +53,13 @@ let distro_status (d:t) : status = match d with
   | `Alpine `V3_11 -> `Active `Tier2
   | `Alpine `V3_12 -> `Active `Tier1
   | `Alpine `Latest -> `Alias (`Alpine `V3_11)
+  | `Archlinux `Latest -> `Active `Tier2
   | `CentOS (`V7 | `V8) -> `Active `Tier2
   | `CentOS `V6 -> `Deprecated
   | `CentOS `Latest -> `Alias (`CentOS `V7)
   | `Debian `V7 -> `Deprecated
-  | `Debian `V8  -> `Active `Tier2
-  | `Debian `V9 -> `Active `Tier2
+  | `Debian `V8  -> `Deprecated
+  | `Debian `V9 -> `Deprecated
   | `Debian `V10 -> `Active `Tier1
   | `Debian `Stable -> `Alias (`Debian `V10)
   | `Debian `Testing -> `Active `Tier2
@@ -77,7 +80,7 @@ let distro_status (d:t) : status = match d with
   | `Ubuntu `Latest -> `Alias (`Ubuntu `V19_10)
 
 let latest_distros =
-  [ `Alpine `Latest; `CentOS `Latest;
+  [ `Alpine `Latest; `Archlinux `Latest; `CentOS `Latest;
     `Debian `Stable; `OracleLinux `Latest; `OpenSUSE `Latest;
     `Fedora `Latest; `Ubuntu `Latest; `Ubuntu `LTS ]
 
@@ -144,6 +147,7 @@ let builtin_ocaml_of_distro (d:t) : string option =
   |`Alpine `V3_10 -> Some "4.07.0"
   |`Alpine `V3_11 -> Some "4.08.1"
   |`Alpine `V3_12 -> Some "4.08.1"
+  |`Archlinux `Latest -> Some "4.11.1"
   |`Fedora `V21 -> Some "4.01.0"
   |`Fedora `V22 -> Some "4.02.0"
   |`Fedora `V23 -> Some "4.02.2"
@@ -224,6 +228,7 @@ let tag_of_distro (d:t) = match d with
   |`Alpine `V3_11 -> "alpine-3.11"
   |`Alpine `V3_12 -> "alpine-3.12"
   |`Alpine `Latest -> "alpine"
+  |`Archlinux `Latest -> "archlinux"
   |`OpenSUSE `V42_1 -> "opensuse-42.1"
   |`OpenSUSE `V42_2 -> "opensuse-42.2"
   |`OpenSUSE `V42_3 -> "opensuse-42.3"
@@ -284,6 +289,7 @@ let distro_of_tag x : t option = match x with
   |"alpine-3.11" -> Some (`Alpine `V3_11)
   |"alpine-3.12" -> Some (`Alpine `V3_12)
   |"alpine" -> Some (`Alpine `Latest)
+  |"archlinux" -> Some (`Archlinux `Latest)
   |"opensuse-42.1" -> Some (`OpenSUSE `V42_1)
   |"opensuse-42.2" -> Some (`OpenSUSE `V42_2)
   |"opensuse-42.3" -> Some (`OpenSUSE `V42_3)
@@ -342,6 +348,7 @@ let rec human_readable_string_of_distro (d:t) =
   |`Alpine `V3_10 -> "Alpine 3.10"
   |`Alpine `V3_11 -> "Alpine 3.11"
   |`Alpine `V3_12 -> "Alpine 3.12"
+  |`Archlinux `Latest -> "Archlinux"
   |`OpenSUSE `V42_1 -> "OpenSUSE 42.1"
   |`OpenSUSE `V42_2 -> "OpenSUSE 42.2"
   |`OpenSUSE `V42_3 -> "OpenSUSE 42.3"
@@ -359,6 +366,7 @@ let human_readable_short_string_of_distro (t:t) =
   |`Fedora _ -> "Fedora"
   |`OracleLinux _ -> "OracleLinux"
   |`Alpine _ -> "Alpine"
+  |`Archlinux _ -> "Archlinux"
   |`OpenSUSE _ -> "OpenSUSE"
 
 (* The alias tag for the latest stable version of this distro *)
@@ -370,9 +378,10 @@ let latest_tag_of_distro (t:t) =
   |`Fedora _ -> "fedora"
   |`OracleLinux _ -> "oraclelinux"
   |`Alpine _ -> "alpine"
+  |`Archlinux _ -> "archlinux"
   |`OpenSUSE _ -> "opensuse"
 
-type package_manager = [ `Apt | `Yum | `Apk | `Zypper ] [@@deriving sexp]
+type package_manager = [ `Apt | `Yum | `Apk | `Zypper | `Pacman ] [@@deriving sexp]
 
 let package_manager (t:t) =
   match t with
@@ -382,6 +391,7 @@ let package_manager (t:t) =
   |`Fedora _ -> `Yum
   |`OracleLinux _ -> `Yum
   |`Alpine _ -> `Apk
+  |`Archlinux _ -> `Pacman
   |`OpenSUSE _ -> `Zypper
 
 let base_distro_tag ?(arch=`X86_64) d =
@@ -405,6 +415,8 @@ let base_distro_tag ?(arch=`X86_64) d =
         | `I386 -> "i386/alpine", tag
         | _ -> "alpine", tag
    end
+  | `Archlinux `Latest ->
+      "archlinux", "latest"
    | `Debian v -> begin
         let tag =
           match v with

--- a/src-opam/dockerfile_distro.ml
+++ b/src-opam/dockerfile_distro.ml
@@ -397,97 +397,97 @@ let package_manager (t:t) =
 let base_distro_tag ?(arch=`X86_64) d =
   match resolve_alias d with
   | `Alpine v -> begin
-        let tag =
-          match v with
-          | `V3_3 -> "3.3"
-          | `V3_4 -> "3.4"
-          | `V3_5 -> "3.5"
-          | `V3_6 -> "3.6"
-          | `V3_7 -> "3.7"
-          | `V3_8 -> "3.8"
-          | `V3_9 -> "3.9"
-          | `V3_10 -> "3.10"
-          | `V3_11 -> "3.11"
-          | `V3_12 -> "3.12"
-          | `Latest -> assert false
-        in
-        match arch with
-        | `I386 -> "i386/alpine", tag
-        | _ -> "alpine", tag
-   end
+      let tag =
+        match v with
+        | `V3_3 -> "3.3"
+        | `V3_4 -> "3.4"
+        | `V3_5 -> "3.5"
+        | `V3_6 -> "3.6"
+        | `V3_7 -> "3.7"
+        | `V3_8 -> "3.8"
+        | `V3_9 -> "3.9"
+        | `V3_10 -> "3.10"
+        | `V3_11 -> "3.11"
+        | `V3_12 -> "3.12"
+        | `Latest -> assert false
+      in
+      match arch with
+      | `I386 -> "i386/alpine", tag
+      | _ -> "alpine", tag
+    end
   | `Archlinux `Latest ->
       "archlinux", "latest"
-   | `Debian v -> begin
-        let tag =
-          match v with
-          | `V7 -> "7"
-          | `V8 -> "8"
-          | `V9 -> "9"
-          | `V10 -> "buster"
-          | `Testing -> "testing"
-          | `Unstable -> "unstable"
-          | `Stable -> assert false
-        in
-        match arch with
-        | `I386 -> "i386/debian", tag
-        | `Aarch32 -> "arm32v7/debian", tag
-        | _ -> "debian", tag
+  | `Debian v -> begin
+      let tag =
+        match v with
+        | `V7 -> "7"
+        | `V8 -> "8"
+        | `V9 -> "9"
+        | `V10 -> "buster"
+        | `Testing -> "testing"
+        | `Unstable -> "unstable"
+        | `Stable -> assert false
+      in
+      match arch with
+      | `I386 -> "i386/debian", tag
+      | `Aarch32 -> "arm32v7/debian", tag
+      | _ -> "debian", tag
     end
-    | `Ubuntu v ->
-        let tag =
-          match v with
-          | `V12_04 -> "precise"
-          | `V14_04 -> "trusty"
-          | `V15_04 -> "vivid"
-          | `V15_10 -> "wily"
-          | `V16_04 -> "xenial"
-          | `V16_10 -> "yakkety"
-          | `V17_04 -> "zesty"
-          | `V17_10 -> "artful"
-          | `V18_04 -> "bionic"
-          | `V18_10 -> "cosmic"
-          | `V19_04 -> "disco"
-          | `V19_10 -> "eoan"
-          | `V20_04 -> "focal"
-          | `Latest | `LTS -> assert false
-        in
-        "ubuntu", tag
-    | `CentOS v ->
-        let tag = match v with `V6 -> "6" | `V7 -> "7" | `V8 -> "8" | _ -> assert false in
-        "centos", tag
-    | `Fedora v ->
-        let tag =
-          match v with
-          | `V21 -> "21"
-          | `V22 -> "22"
-          | `V23 -> "23"
-          | `V24 -> "24"
-          | `V25 -> "25"
-          | `V26 -> "26"
-          | `V27 -> "27"
-          | `V28 -> "28"
-          | `V29 -> "29"
-          | `V30 -> "30"
-          | `V31 -> "31"
-          | `V32 -> "32"
-          | `Latest -> assert false
-        in
-        "fedora", tag
-    | `OracleLinux v ->
-        let tag = match v with `V7 -> "7" | _ -> assert false in
-        "oraclelinux", tag
-    | `OpenSUSE v ->
-        let tag =
-          match v with
-          | `V42_1 -> "42.1"
-          | `V42_2 -> "42.2"
-          | `V42_3 -> "42.3"
-          | `V15_0 -> "15.0"
-          | `V15_1 -> "15.1"
-          | `V15_2 -> "15.2"
-          | `Latest -> assert false
-        in
-        "opensuse/leap", tag
+  | `Ubuntu v ->
+      let tag =
+        match v with
+        | `V12_04 -> "precise"
+        | `V14_04 -> "trusty"
+        | `V15_04 -> "vivid"
+        | `V15_10 -> "wily"
+        | `V16_04 -> "xenial"
+        | `V16_10 -> "yakkety"
+        | `V17_04 -> "zesty"
+        | `V17_10 -> "artful"
+        | `V18_04 -> "bionic"
+        | `V18_10 -> "cosmic"
+        | `V19_04 -> "disco"
+        | `V19_10 -> "eoan"
+        | `V20_04 -> "focal"
+        | `Latest | `LTS -> assert false
+      in
+      "ubuntu", tag
+  | `CentOS v ->
+      let tag = match v with `V6 -> "6" | `V7 -> "7" | `V8 -> "8" | _ -> assert false in
+      "centos", tag
+  | `Fedora v ->
+      let tag =
+        match v with
+        | `V21 -> "21"
+        | `V22 -> "22"
+        | `V23 -> "23"
+        | `V24 -> "24"
+        | `V25 -> "25"
+        | `V26 -> "26"
+        | `V27 -> "27"
+        | `V28 -> "28"
+        | `V29 -> "29"
+        | `V30 -> "30"
+        | `V31 -> "31"
+        | `V32 -> "32"
+        | `Latest -> assert false
+      in
+      "fedora", tag
+  | `OracleLinux v ->
+      let tag = match v with `V7 -> "7" | _ -> assert false in
+      "oraclelinux", tag
+  | `OpenSUSE v ->
+      let tag =
+        match v with
+        | `V42_1 -> "42.1"
+        | `V42_2 -> "42.2"
+        | `V42_3 -> "42.3"
+        | `V15_0 -> "15.0"
+        | `V15_1 -> "15.1"
+        | `V15_2 -> "15.2"
+        | `Latest -> assert false
+      in
+      "opensuse/leap", tag
 
 let compare a b =
   String.compare (human_readable_string_of_distro a) (human_readable_string_of_distro b)

--- a/src-opam/dockerfile_distro.mli
+++ b/src-opam/dockerfile_distro.mli
@@ -24,6 +24,7 @@
 
 type t = [
   | `Alpine of [ `V3_3 | `V3_4 | `V3_5 | `V3_6 | `V3_7 | `V3_8 | `V3_9 | `V3_10 | `V3_11 | `V3_12 | `Latest ]
+  | `Archlinux of [ `Latest ]
   | `CentOS of [ `V6 | `V7 | `V8 | `Latest ]
   | `Debian of [ `V10 | `V9 | `V8 | `V7 | `Stable | `Testing | `Unstable ]
   | `Fedora of [ `V21 | `V22 | `V23 | `V24 | `V25 | `V26 | `V27 | `V28 | `V29 | `V30 | `V31 | `V32 | `Latest ]
@@ -67,7 +68,9 @@ type package_manager = [
   | `Apk  (** Alpine Apk *)
   | `Apt  (** Debian Apt *)
   | `Yum  (** Fedora Yum *)
-  | `Zypper (** OpenSUSE Zypper *) ] [@@deriving sexp]
+  | `Zypper (** OpenSUSE Zypper *)
+  | `Pacman (** Archlinux Pacman *)
+] [@@deriving sexp]
 (** The package manager used by a distro. *)
 
 val package_manager : t -> package_manager

--- a/src-opam/dockerfile_linux.ml
+++ b/src-opam/dockerfile_linux.ml
@@ -181,18 +181,17 @@ module Pacman = struct
 
   let add_user ?uid ?gid ?(sudo=false) username =
     let home = "/home/"^username in
-    run "adduser -S %s%s%s"
+    run "useradd %s%s -d %s -m --user-group %s"
       (match uid with None -> "" | Some d -> sprintf "-u %d " d)
       (match gid with None -> "" | Some g -> sprintf "-g %d " g)
-      username @@
+      home username @@
     (match sudo with
     | false -> empty
     | true ->
         let sudofile = "/etc/sudoers.d/"^username in
         run "echo '%s %s' > %s" username sudo_nopasswd sudofile @@
         run "chmod 440 %s" sudofile @@
-        run "chown root:root %s" sudofile @@
-        run "sed -i.bak 's/^Defaults.*requiretty//g' /etc/sudoers") @@
+        run "chown root:root %s" sudofile) @@
     user "%s" username @@
     workdir "%s" home @@
     run "mkdir .ssh" @@

--- a/src-opam/dockerfile_linux.mli
+++ b/src-opam/dockerfile_linux.mli
@@ -118,6 +118,27 @@ module Zypper : sig
   (** Install the system OCaml packages via [zypper] *)
 end
 
+(** Rules for Pacman-based distributions such as Archlinux *)
+module Pacman : sig
+  val update : t
+  (** [update] will run [pacman -Syu] non-interactively. *)
+
+  val install : ('a, unit, string, t) format4 -> 'a
+  (** [install fmt] will [pacman -Syu] the packages specified by the [fmt] format string. *)
+
+  val add_user : ?uid:int -> ?gid:int -> ?sudo:bool -> string -> t
+  (** [add_user username] will install a new user with name [username] and a locked
+      password.  If [sudo] is true then root access with no password will also be
+      configured.  The default value for [sudo] is [false]. *)
+
+  val dev_packages : ?extra:string -> unit -> t
+  (** [dev_packages ?extra ()] will install the base development tools and [sudo],
+      [passwd] and [git].  Extra packages may also be optionally supplied via [extra]. *)
+
+  val install_system_ocaml : t
+  (** Install the system OCaml packages via [pacman] *)
+end
+
 (** Rules for Git *)
 module Git : sig
   val init : ?name:string -> ?email:string -> unit -> t

--- a/src-opam/dockerfile_opam.ml
+++ b/src-opam/dockerfile_opam.ml
@@ -181,8 +181,8 @@ let pacman_opam2 ?(labels=[]) ?arch ~distro ~tag () =
   @@ copy ~from:"0" ~src:["/usr/local/bin/opam-2.0"] ~dst:"/usr/bin/opam-2.0" ()
   @@ copy ~from:"0" ~src:["/usr/local/bin/opam-master"] ~dst:"/usr/bin/opam-2.1" ()
   @@ run "ln /usr/bin/opam-2.0 /usr/bin/opam"
-  @@ Linux.Apk.dev_packages ()
-  @@ Linux.Apk.add_user ~uid:1000 ~gid:1000 ~sudo:true "opam"
+  @@ Linux.Pacman.dev_packages ()
+  @@ Linux.Pacman.add_user ~uid:1000 ~gid:1000 ~sudo:true "opam"
   @@ install_bubblewrap_wrappers @@ Linux.Git.init ()
 
 let gen_opam2_distro ?(clone_opam_repo=true) ?arch ?labels d =

--- a/src-opam/dockerfile_opam.ml
+++ b/src-opam/dockerfile_opam.ml
@@ -182,7 +182,7 @@ let pacman_opam2 ?(labels=[]) ?arch ~distro ~tag () =
   @@ copy ~from:"0" ~src:["/usr/local/bin/opam-master"] ~dst:"/usr/bin/opam-2.1" ()
   @@ run "ln /usr/bin/opam-2.0 /usr/bin/opam"
   @@ Linux.Pacman.dev_packages ()
-  @@ Linux.Pacman.add_user ~uid:1000 ~gid:1000 ~sudo:true "opam"
+  @@ Linux.Pacman.add_user ~uid:1000 ~sudo:true "opam"
   @@ install_bubblewrap_wrappers @@ Linux.Git.init ()
 
 let gen_opam2_distro ?(clone_opam_repo=true) ?arch ?labels d =

--- a/src-opam/dockerfile_opam.ml
+++ b/src-opam/dockerfile_opam.ml
@@ -172,7 +172,7 @@ let zypper_opam2 ?(labels=[]) ?arch ~distro ~tag () =
 (* Pacman based Dockerfile *)
 let pacman_opam2 ?(labels=[]) ?arch ~distro ~tag () =
   header ?arch distro tag @@ label (("distro_style", "pacman") :: labels)
-  @@ Linux.Pacman.install "make gcc bzip2 git tar curl ca-certificates openssl"
+  @@ Linux.Pacman.install "make gcc patch bzip2 git tar curl ca-certificates openssl"
   @@ Linux.Git.init ()
   @@ install_opam_from_source ~add_default_link:false ~branch:"2.0" ()
   @@ install_opam_from_source ~add_default_link:false ~branch:"master" ()

--- a/src-opam/dockerfile_opam.ml
+++ b/src-opam/dockerfile_opam.ml
@@ -61,7 +61,7 @@ let install_bubblewrap_wrappers =
   run "echo 'echo --- opam sandboxing enabled' >> /home/opam/opam-sandbox-enable" @@
   run "chmod a+x /home/opam/opam-sandbox-enable" @@
   run "sudo mv /home/opam/opam-sandbox-enable /usr/bin/opam-sandbox-enable"
-   
+
 let header ?arch ?maintainer img tag =
   let platform =
     match arch with
@@ -233,7 +233,7 @@ let all_ocaml_compilers hub_id arch distro =
     @@ workdir "/home/opam/opam-repository" @@ run "git pull origin master"
     @@ run "opam-sandbox-disable"
     @@ run "opam init -k git -a /home/opam/opam-repository --bare"
-    @@ compilers 
+    @@ compilers
     @@ run "opam switch %s" (OV.(to_string (with_patch OV.Releases.latest None)))
     @@ entrypoint_exec (pers @ ["opam"; "config"; "exec"; "--"])
     @@ run "opam install -y depext"
@@ -249,7 +249,7 @@ let tag_of_ocaml_version ov =
 
 let separate_ocaml_compilers hub_id arch distro =
   let distro_tag = D.tag_of_distro distro in
-  OV.Releases.recent_with_dev |> List.filter (fun ov -> D.distro_supported_on arch ov distro) 
+  OV.Releases.recent_with_dev |> List.filter (fun ov -> D.distro_supported_on arch ov distro)
   |> List.map (fun ov ->
          let add_remote =
            if OV.Releases.is_dev ov then
@@ -286,7 +286,7 @@ let bulk_build prod_hub_id distro ocaml_version opam_repo_rev =
   let tag =
     if use_main_tag then
       Fmt.strf "%s-ocaml-%s" (D.tag_of_distro distro) OV.(to_string (with_variant ocaml_version None))
-    else 
+    else
       D.tag_of_distro distro
   in
   header prod_hub_id tag


### PR DESCRIPTION
Docker now offers `archlinux` as an official image (https://hub.docker.com/_/archlinux) since last year. I remember having looked around for one not long before and I seem to have missed the news.

Anyway, I think that'd be really good to add it to the CI test array. https://github.com/ocaml-opam/opam-depext/pull/123 fixed the archlinux support and a new release of `opam-depext` is due soon. Anytime after that would be fine to merge this.