### PR TITLE
Move more distros over to Tier 3 support from Tier 2

### DIFF
--- a/src-opam/dockerfile_distro.ml
+++ b/src-opam/dockerfile_distro.ml
@@ -52,8 +52,9 @@ let distro_status (d:t) : status = match d with
   | `Alpine (`V3_3 | `V3_4 | `V3_5 | `V3_6 | `V3_7 | `V3_8 | `V3_9 | `V3_10 | `V3_11) -> `Deprecated
   | `Alpine `V3_12 -> `Active `Tier1
   | `Alpine `Latest -> `Alias (`Alpine `V3_12)
-  | `Archlinux `Latest -> `Active `Tier2
-  | `CentOS (`V7 | `V8) -> `Active `Tier2
+  | `Archlinux `Latest -> `Active `Tier3
+  | `CentOS `V8 -> `Active `Tier2
+  | `CentOS `V7 -> `Active `Tier3
   | `CentOS `V6 -> `Deprecated
   | `CentOS `Latest -> `Alias (`CentOS `V8)
   | `Debian `V7 -> `Deprecated
@@ -61,18 +62,18 @@ let distro_status (d:t) : status = match d with
   | `Debian `V9 -> `Deprecated
   | `Debian `V10 -> `Active `Tier1
   | `Debian `Stable -> `Alias (`Debian `V10)
-  | `Debian `Testing -> `Active `Tier2
-  | `Debian `Unstable -> `Active `Tier2
-  | `Fedora ( `V21 | `V22 | `V23 | `V24 | `V25 | `V26 | `V27 | `V28 | `V29 | `V30 | `V31) -> `Deprecated
-  | `Fedora (`V32|`V33) -> `Active `Tier2
+  | `Debian `Testing -> `Active `Tier3
+  | `Debian `Unstable -> `Active `Tier3
+  | `Fedora ( `V21 | `V22 | `V23 | `V24 | `V25 | `V26 | `V27 | `V28 | `V29 | `V30 | `V31 | `V32) -> `Deprecated
+  | `Fedora `V33 -> `Active `Tier2
   | `Fedora `Latest -> `Alias (`Fedora `V33)
-  | `OracleLinux `V8 -> `Active `Tier2
-  | `OracleLinux `V7 -> `Active `Tier3
+  | `OracleLinux (`V7|`V8) -> `Active `Tier3
   | `OracleLinux `Latest -> `Alias (`OracleLinux `V8)
   | `OpenSUSE (`V42_1 | `V42_2 | `V42_3 | `V15_0 | `V15_1) -> `Deprecated
   | `OpenSUSE `V15_2 -> `Active `Tier2
   | `OpenSUSE `Latest -> `Alias (`OpenSUSE `V15_2)
-  | `Ubuntu (`V16_04 | `V18_04 | `V20_04 | `V20_10) -> `Active `Tier2
+  | `Ubuntu (`V16_04 | `V18_04) -> `Active `Tier3
+  | `Ubuntu (`V20_04|`V20_10) -> `Active `Tier2
   | `Ubuntu ( `V12_04 | `V14_04 | `V15_04 | `V15_10 | `V16_10 | `V17_04 | `V17_10 | `V18_10 | `V19_04 | `V19_10 ) -> `Deprecated
   | `Ubuntu `LTS -> `Alias (`Ubuntu `V20_04)
   | `Ubuntu `Latest -> `Alias (`Ubuntu `V20_10)


### PR DESCRIPTION
Since Tier 2 is the level at which ocaml-ci will also test,
we move more distros over to Tier 3.
See https://github.com/ocurrent/ocaml-ci/pull/259 for more
discussion about this change.