### PR TITLE
Install yum if not present

### DIFF
--- a/src-opam/dockerfile_opam.ml
+++ b/src-opam/dockerfile_opam.ml
@@ -136,6 +136,7 @@ let yum_opam2 ?(labels= []) ?arch ~yum_workaround ~enable_powertools ~distro ~ta
     else empty
   in
   header ?arch distro tag @@ label (("distro_style", "rpm") :: labels)
+  @@ run "yum --version || dnf install -y yum"
   @@ workaround
   @@ Linux.RPM.update
   @@ Linux.RPM.dev_packages ~extra:"which tar curl xz libcap-devel openssl" ()


### PR DESCRIPTION
Should fix the current issue when building `oraclelinux-8`. The base image does not ship with yum anymore since https://github.com/oracle/container-images/commit/2f03b19e3230373aba31a91b315b1bbd1ff1998b