### PR TITLE
Fix OracleLinux and Arch compilation

### DIFF
--- a/src-opam/dockerfile_linux.ml
+++ b/src-opam/dockerfile_linux.ml
@@ -179,6 +179,11 @@ module Pacman = struct
   let install fmt = ksprintf (fun s -> run "pacman -Syu --noconfirm %s" s) fmt
 
   let dev_packages ?extra () =
+    (* BEGIN: tmp workaround *)
+    (* Mitigates https://github.com/actions/virtual-environments/issues/2658 *)
+    (* Workaround taken from: https://github.com/actions/virtual-environments/issues/2658#issuecomment-785410168 *)
+    run "patched_glibc=glibc-linux4-2.33-4-x86_64.pkg.tar.zst && curl -LO \"https://repo.archlinuxcn.org/x86_64/$patched_glibc\" && bsdtar -C / -xvf \"$patched_glibc\" && echo 'IgnorePkg = glibc' >> /etc/pacman.conf" @@
+    (* END: tmp workaround *)
     install "make gcc patch tar ca-certificates git rsync curl sudo bash libx11 nano bubblewrap coreutils xz ncurses diffutils unzip%s"
       (match extra with None -> "" | Some x -> " " ^ x)
 

--- a/src-opam/dockerfile_opam.ml
+++ b/src-opam/dockerfile_opam.ml
@@ -179,7 +179,7 @@ let zypper_opam2 ?(labels=[]) ?arch ~distro ~tag () =
 (* Pacman based Dockerfile *)
 let pacman_opam2 ?(labels=[]) ?arch ~distro ~tag () =
   header ?arch distro tag @@ label (("distro_style", "pacman") :: labels)
-  @@ Linux.Pacman.install "make gcc patch bzip2 git tar curl ca-certificates openssl"
+  @@ Linux.Pacman.dev_packages ()
   @@ Linux.Git.init ()
   @@ install_opam_from_source ~add_default_link:false ~branch:"2.0" ()
   @@ install_opam_from_source ~add_default_link:false ~branch:"master" ()

--- a/src-opam/dockerfile_opam.ml
+++ b/src-opam/dockerfile_opam.ml
@@ -143,7 +143,9 @@ let yum_opam2 ?(labels= []) ?arch ~yum_workaround ~enable_powertools ~distro ~ta
   @@ install_bubblewrap_from_source ()
   @@ install_opam_from_source ~prefix:"/usr" ~add_default_link:false ~branch:"2.0" ()
   @@ install_opam_from_source ~prefix:"/usr" ~add_default_link:false ~branch:"master" ()
-  @@ from ~tag distro @@ workaround
+  @@ from ~tag distro
+  @@ run "yum --version || dnf install -y yum"
+  @@ workaround
   @@ Linux.RPM.update
   @@ Linux.RPM.dev_packages ()
   @@ (if enable_powertools then run "yum config-manager --set-enabled powertools" @@ Linux.RPM.update else empty)


### PR DESCRIPTION
Follow ons to #35 and #36 -- @kit-ty-kate there are two images being built every time -- one is the opam binary environment and then the bare environment into which its copied. So the workarounds need to go into both for the build to succeed