### PR TITLE
Enable the 0install-solver when installing opam from source

### DIFF
--- a/src-opam/dockerfile_opam.ml
+++ b/src-opam/dockerfile_opam.ml
@@ -30,10 +30,11 @@ let personality ?arch distro =
 
 let run_as_opam fmt = Linux.run_as_user "opam" fmt
 
-let install_opam_from_source ?(add_default_link=true) ?(prefix= "/usr/local") ~branch () =
+let install_opam_from_source ?(add_default_link=true) ?(prefix= "/usr/local") ?(enable_0install_solver=false) ~branch () =
   run "git clone -b %s git://github.com/ocaml/opam /tmp/opam" branch @@
   Linux.run_sh
-       "cd /tmp/opam && make cold && mkdir -p %s/bin && cp /tmp/opam/opam %s/bin/opam-%s && chmod a+x %s/bin/opam-%s && rm -rf /tmp/opam" prefix prefix branch prefix branch @@
+    "cd /tmp/opam && make%s cold && mkdir -p %s/bin && cp /tmp/opam/opam %s/bin/opam-%s && chmod a+x %s/bin/opam-%s && rm -rf /tmp/opam"
+    (if enable_0install_solver then " CONFIGURE_ARGS=--with-0install-solver" else "") prefix prefix branch prefix branch @@
   if add_default_link then
     run "ln %s/bin/opam-%s %s/bin/opam" prefix branch prefix
   else empty
@@ -104,7 +105,7 @@ let apk_opam2 ?(labels=[]) ?arch distro () =
   @@ Linux.Apk.install "build-base bzip2 git tar curl ca-certificates openssl"
   @@ Linux.Git.init ()
   @@ install_opam_from_source ~add_default_link:false ~branch:"2.0" ()
-  @@ install_opam_from_source ~add_default_link:false ~branch:"master" ()
+  @@ install_opam_from_source ~add_default_link:false ~enable_0install_solver:true ~branch:"master" ()
   @@ run "strip /usr/local/bin/opam*"
   @@ from ~tag img
   @@ Linux.Apk.add_repository ~tag:"testing" "http://dl-cdn.alpinelinux.org/alpine/edge/testing"
@@ -124,7 +125,7 @@ let apt_opam2 ?(labels=[]) ?arch distro () =
   @@ Linux.Git.init ()
   @@ install_bubblewrap_from_source ()
   @@ install_opam_from_source ~add_default_link:false ~branch:"2.0" ()
-  @@ install_opam_from_source ~add_default_link:false ~branch:"master" ()
+  @@ install_opam_from_source ~add_default_link:false ~enable_0install_solver:true ~branch:"master" ()
   @@ from ~tag img
   @@ copy ~from:"0" ~src:["/usr/local/bin/bwrap"] ~dst:"/usr/bin/bwrap" ()
   @@ copy ~from:"0" ~src:["/usr/local/bin/opam-2.0"] ~dst:"/usr/bin/opam-2.0" ()
@@ -160,7 +161,7 @@ let yum_opam2 ?(labels= []) ?arch ~yum_workaround ~enable_powertools distro () =
   @@ Linux.Git.init ()
   @@ install_bubblewrap_from_source ()
   @@ install_opam_from_source ~prefix:"/usr" ~add_default_link:false ~branch:"2.0" ()
-  @@ install_opam_from_source ~prefix:"/usr" ~add_default_link:false ~branch:"master" ()
+  @@ install_opam_from_source ~prefix:"/usr" ~add_default_link:false ~enable_0install_solver:true ~branch:"master" ()
   @@ from ~tag img
   @@ run "yum --version || dnf install -y yum"
   @@ workaround
@@ -185,7 +186,7 @@ let zypper_opam2 ?(labels=[]) ?arch distro () =
   @@ Linux.Git.init ()
   @@ install_bubblewrap_from_source ()
   @@ install_opam_from_source ~prefix:"/usr" ~add_default_link:false ~branch:"2.0" ()
-  @@ install_opam_from_source ~prefix:"/usr" ~add_default_link:false ~branch:"master" ()
+  @@ install_opam_from_source ~prefix:"/usr" ~add_default_link:false ~enable_0install_solver:true ~branch:"master" ()
   @@ from ~tag img
   @@ Linux.Zypper.dev_packages ()
   @@ copy ~from:"0" ~src:["/usr/local/bin/bwrap"] ~dst:"/usr/bin/bwrap" ()
@@ -202,7 +203,7 @@ let pacman_opam2 ?(labels=[]) ?arch distro () =
   @@ Linux.Pacman.dev_packages ()
   @@ Linux.Git.init ()
   @@ install_opam_from_source ~add_default_link:false ~branch:"2.0" ()
-  @@ install_opam_from_source ~add_default_link:false ~branch:"master" ()
+  @@ install_opam_from_source ~add_default_link:false ~enable_0install_solver:true ~branch:"master" ()
   @@ run "strip /usr/local/bin/opam*"
   @@ from ~tag img
   @@ copy ~from:"0" ~src:["/usr/local/bin/opam-2.0"] ~dst:"/usr/bin/opam-2.0" ()

--- a/src-opam/dockerfile_opam.mli
+++ b/src-opam/dockerfile_opam.mli
@@ -27,7 +27,7 @@ val run_as_opam : ('a, unit, string, Dockerfile.t) format4 -> 'a
     format string as the [opam] user. *)
 
 val install_opam_from_source : ?add_default_link:bool ->
-  ?prefix:string -> branch:string -> unit -> Dockerfile.t
+  ?prefix:string -> ?enable_0install_solver:bool -> branch:string -> unit -> Dockerfile.t
 (** Commands to install OPAM via a source code checkout from GitHub.
     The [branch] can be a git tag or branch (e.g. [2.0] for opam 2.x or [master] for
     the latest trunk version).
@@ -35,7 +35,9 @@ val install_opam_from_source : ?add_default_link:bool ->
     defaulting to [/usr/local/bin].
     If [add_default_link] is true (the default), then the [opam-<branch>]
     binary is hardlinked to [opam].  Set it to false if you want to install
-    multiple opam binaries from different branches in the same container. *)
+    multiple opam binaries from different branches in the same container.
+    If [enable_0install_solver] is true (false by default), then the [builtin-0install]
+    solver should be accessible in the resulting opam binary. *)
 
 val gen_opam2_distro :
   ?clone_opam_repo:bool ->


### PR DESCRIPTION
Requires https://github.com/ocaml/opam/pull/4646 to be merged first
Used in https://github.com/ocurrent/docker-base-images/pull/102