### PR TITLE
Deprecate Ubuntu 16.04 (EOL)

### DIFF
--- a/src-opam/dockerfile_distro.ml
+++ b/src-opam/dockerfile_distro.ml
@@ -104,9 +104,9 @@ let distro_status (d:t) : status = match d with
   | `OpenSUSE (`V42_1 | `V42_2 | `V42_3 | `V15_0 | `V15_1) -> `Deprecated
   | `OpenSUSE `V15_2 -> `Active `Tier2
   | `OpenSUSE `Latest -> `Alias (`OpenSUSE `V15_2)
-  | `Ubuntu (`V16_04 | `V18_04) -> `Active `Tier3
+  | `Ubuntu (`V18_04) -> `Active `Tier3
   | `Ubuntu (`V20_04|`V20_10 |`V21_04) -> `Active `Tier2
-  | `Ubuntu ( `V12_04 | `V14_04 | `V15_04 | `V15_10 | `V16_10 | `V17_04 | `V17_10 | `V18_10 | `V19_04 | `V19_10 ) -> `Deprecated
+  | `Ubuntu ( `V12_04 | `V14_04 | `V15_04 | `V15_10 | `V16_04 | `V16_10 | `V17_04 | `V17_10 | `V18_10 | `V19_04 | `V19_10 ) -> `Deprecated
   | `Ubuntu `LTS -> `Alias (`Ubuntu `V20_04)
   | `Ubuntu `Latest -> `Alias (`Ubuntu `V20_10)
   | `Cygwin `V20H2 -> `Active `Tier3


### PR DESCRIPTION
End of Life is on April 30th 2021. See https://help.ubuntu.com/community/EOL#Ubuntu_16.04_Xenial_Xerus