### PR TITLE
Add @edge and @edgecommunity to /etc/apk/repositories.

### DIFF
--- a/src-opam/dockerfile_opam.ml
+++ b/src-opam/dockerfile_opam.ml
@@ -117,7 +117,9 @@ let apk_opam2 ?(labels=[]) ?arch distro () =
   @@ install_opam_from_source ~add_default_link:false ~branch:"master" ()
   @@ run "strip /usr/local/bin/opam*"
   @@ from ~tag img
-  @@ Linux.Apk.add_repository ~tag:"testing" "http://dl-cdn.alpinelinux.org/alpine/edge/testing"
+  @@ Linux.Apk.add_repository ~tag:"edge" "https://dl-cdn.alpinelinux.org/alpine/edge/main"
+  @@ Linux.Apk.add_repository ~tag:"edgecommunity" "https://dl-cdn.alpinelinux.org/alpine/edge/community"
+  @@ Linux.Apk.add_repository ~tag:"testing" "https://dl-cdn.alpinelinux.org/alpine/edge/testing"
   @@ copy ~from:"0" ~src:["/usr/local/bin/opam-2.0"] ~dst:"/usr/bin/opam-2.0" ()
   @@ copy ~from:"0" ~src:["/usr/local/bin/opam-master"] ~dst:"/usr/bin/opam-2.1" ()
   @@ run "ln /usr/bin/opam-2.0 /usr/bin/opam"


### PR DESCRIPTION
When generating APK-based Dockerfiles, add @edge and @edgecommunity
entries to /etc/apk/repositories.  This allows users of these images
to reference packages in the edge repos.  We need @edgecommunity
immediately for capnproto, which recently moved from @testing to
@edgecommunity.  The @edge entry is for completeness.

Note that the naming conventions here are taken from
https://wiki.alpinelinux.org/wiki/Alpine_Linux_package_management#Repository_pinning,
so they are presumably established in the Alpine community.

Also, switch the URLs to https, because everything should be HTTPS,
not least for sites from which we're downloading trusted software packages.

Signed-off-by: Ewan Mellor <ewan@tarides.com>