### PR TITLE
Better support for Windows 10 Updates

### DIFF
--- a/src-opam/dockerfile_distro.ml
+++ b/src-opam/dockerfile_distro.ml
@@ -20,7 +20,7 @@ open Astring
 
 type win10_release = [
   | `V1507 | `Ltsc2015 | `V1511 | `V1607 | `Ltsc2016 | `V1703 | `V1709
-  | `V1803 | `V1809 | `Ltsc2019 | `V1903 | `V1909 | `V2004 | `V20H2
+  | `V1803 | `V1809 | `Ltsc2019 | `V1903 | `V1909 | `V2004 | `V20H2 | `V21H1
 ] [@@deriving sexp]
 
 type t = [
@@ -84,7 +84,7 @@ let distros = [
 let distros =
   let win10_releases =
     [ `V1507; `Ltsc2015; `V1511; `V1607; `Ltsc2016; `V1703; `V1709; `V1809;
-      `Ltsc2019; `V1903; `V1909; `V2004; `V20H2; ] in
+      `Ltsc2019; `V1903; `V1909; `V2004; `V20H2; `V21H1 ] in
   List.fold_left (fun distros version ->
       `Cygwin version :: `Windows (`Mingw, version) :: `Windows (`Msvc, version) :: distros)
     distros win10_releases
@@ -103,9 +103,10 @@ let win10_release_status v : win10_release_status = match v with
   | `V1903 -> `Deprecated
   | `V1909
   | `V2004
-  | `V20H2 -> `Active
+  | `V20H2
+  | `V21H1 -> `Active
 
-let win10_latest_release = `V20H2
+let win10_latest_release = `V21H1
 
 type win10_docker_base_image = [ `Windows | `ServerCore | `NanoServer ]
 
@@ -282,14 +283,14 @@ let win10_release_to_string = function
   | `V1607 -> "1607" | `Ltsc2016 -> "ltsc2016" | `V1703 -> "1703"
   | `V1709 -> "1709" | `V1803 -> "1803" | `V1809 -> "1809"
   | `Ltsc2019 -> "ltsc2019" | `V1903 -> "1903" | `V1909 -> "1909"
-  | `V2004 -> "2004" | `V20H2 -> "20H2"
+  | `V2004 -> "2004" | `V20H2 -> "20H2" | `V21H1 -> "21H1"
 
 let win10_release_of_string v : win10_release option = match v with
   | "1507" -> Some `V1507 | "ltsc2015" -> Some `Ltsc2015 | "1511" -> Some `V1511
   | "1607" -> Some `V1607 | "ltsc2016" -> Some `Ltsc2016 | "1703" -> Some `V1703
   | "1709" -> Some `V1709 | "1803" -> Some `V1803 | "1809" -> Some `V1809
   | "ltsc2019" -> Some `Ltsc2019 | "1903" -> Some `V1903 | "1909" -> Some `V1909
-  | "2004" -> Some `V2004 | "20H2" -> Some `V20H2
+  | "2004" -> Some `V2004 | "20H2" -> Some `V20H2 | "21H1" -> Some `V21H1
   | _ -> None
 
 (* The Docker tag for this distro *)

--- a/src-opam/dockerfile_distro.ml
+++ b/src-opam/dockerfile_distro.ml
@@ -217,7 +217,7 @@ let builtin_ocaml_of_distro (d:t) : string option =
   |`OpenSUSE `V15_2 -> Some "4.05.0"
   |`OracleLinux `V7 -> Some "4.01.0"
   |`OracleLinux `V8 -> Some "4.07.0"
-  |`Cygwin `V20H2 -> Some "4.10.0"
+  |`Cygwin _ -> None
   |`Windows _ -> None
   |`Alpine `Latest |`CentOS `Latest |`OracleLinux `Latest
   |`OpenSUSE `Latest |`Ubuntu `LTS | `Ubuntu `Latest

--- a/src-opam/dockerfile_distro.ml
+++ b/src-opam/dockerfile_distro.ml
@@ -105,6 +105,8 @@ let win10_release_status v : win10_release_status = match v with
   | `V2004
   | `V20H2 -> `Active
 
+let win10_latest_release = `V20H2
+
 type win10_docker_base_image = [ `Windows | `ServerCore | `NanoServer ]
 
 (* https://docs.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/base-image-lifecycle *)
@@ -122,6 +124,8 @@ let win10_docker_status (base : win10_docker_base_image) v : status =
   | `ServerCore, (`V1607 | `Ltsc2016) -> `Active `Tier3
   | `NanoServer, `V1607 -> `Deprecated
   | _ -> `Not_available
+
+let win10_latest_image = `V20H2
 
 let distro_status (d:t) : status = match d with
   | `Alpine (`V3_3 | `V3_4 | `V3_5 | `V3_6 | `V3_7 | `V3_8 | `V3_9 | `V3_10 | `V3_11 | `V3_12) -> `Deprecated
@@ -160,7 +164,13 @@ let latest_distros =
   [ `Alpine `Latest; `Archlinux `Latest; `CentOS `Latest;
     `Debian `Stable; `OracleLinux `Latest; `OpenSUSE `Latest;
     `Fedora `Latest; `Ubuntu `Latest; `Ubuntu `LTS;
-    `Cygwin `V20H2; `Windows (`Mingw, `V20H2); `Windows (`Msvc, `V20H2)]
+    (* Prefer win10_latest_image to win10_latest_release as
+       latest_distro is used by docker-base-images to fetch tag
+       aliases. *)
+    `Cygwin win10_latest_image;
+    `Windows (`Mingw, win10_latest_image);
+    `Windows (`Msvc, win10_latest_image);
+  ]
 
 let master_distro = `Debian `Stable
 

--- a/src-opam/dockerfile_distro.ml
+++ b/src-opam/dockerfile_distro.ml
@@ -158,7 +158,13 @@ let distro_status (d:t) : status = match d with
   | `Ubuntu ( `V12_04 | `V14_04 | `V15_04 | `V15_10 | `V16_04 | `V16_10 | `V17_04 | `V17_10 | `V18_10 | `V19_04 | `V19_10 ) -> `Deprecated
   | `Ubuntu `LTS -> `Alias (`Ubuntu `V20_04)
   | `Ubuntu `Latest -> `Alias (`Ubuntu `V20_10)
+  | `Cygwin `Ltsc2019 -> `Alias (`Cygwin `V1809)
+  | `Cygwin `Ltsc2016 -> `Alias (`Cygwin `V1607)
+  | `Cygwin `Ltsc2015 -> `Alias (`Cygwin `V1507)
   | `Cygwin v -> win10_docker_status `ServerCore v
+  | `Windows (cc, `Ltsc2019) -> `Alias (`Windows (cc, `V1809))
+  | `Windows (cc, `Ltsc2016) -> `Alias (`Windows (cc, `V1607))
+  | `Windows (cc, `Ltsc2015) -> `Alias (`Windows (cc, `V1507))
   | `Windows (_, v) -> win10_docker_status `Windows v
 
 let latest_distros =
@@ -272,6 +278,8 @@ let builtin_ocaml_of_distro (d:t) : string option =
   |`OpenSUSE `V15_2 -> Some "4.05.0"
   |`OracleLinux `V7 -> Some "4.01.0"
   |`OracleLinux `V8 -> Some "4.07.0"
+  |`Cygwin (`Ltsc2015 | `Ltsc2016 | `Ltsc2019)
+  |`Windows (_, (`Ltsc2015 | `Ltsc2016 | `Ltsc2019)) -> assert false
   |`Cygwin _ -> None
   |`Windows _ -> None
   |`Alpine `Latest |`CentOS `Latest |`OracleLinux `Latest
@@ -660,8 +668,10 @@ let base_distro_tag ?(arch=`X86_64) d =
         | `Latest -> assert false
       in
       "opensuse/leap", tag
+  | `Cygwin (`Ltsc2015 | `Ltsc2016 | `Ltsc2019) -> assert false
   | `Cygwin v ->
      "mcr.microsoft.com/windows/servercore", win10_release_to_string v
+  | `Windows (_, (`Ltsc2015 | `Ltsc2016 | `Ltsc2019)) -> assert false
   | `Windows (_, v) ->
      "mcr.microsoft.com/windows", win10_release_to_string v
 

--- a/src-opam/dockerfile_distro.mli
+++ b/src-opam/dockerfile_distro.mli
@@ -78,6 +78,14 @@ val distros : t list
 val latest_distros : t list
 (** Enumeration of the latest stable (ideally LTS) supported distributions. *)
 
+val win10_latest_release : win10_release
+(** Latest Windows 10 release. *)
+
+val win10_latest_image : win10_release
+(** Latest Windows 10 Docker image available. May differ from
+   {!win10_latest_release} if the Docker repository hasn't been
+   updated. *)
+
 val master_distro : t
 (** The distribution that is the top-level alias for the [latest] tag
     in the [ocaml/opam2] Docker Hub build. *)

--- a/src-opam/dockerfile_distro.mli
+++ b/src-opam/dockerfile_distro.mli
@@ -24,7 +24,7 @@
 
 type win10_release = [
   | `V1507 | `Ltsc2015 | `V1511 | `V1607 | `Ltsc2016 | `V1703 | `V1709
-  | `V1803 | `V1809 | `Ltsc2019 | `V1903 | `V1909 | `V2004 | `V20H2
+  | `V1803 | `V1809 | `Ltsc2019 | `V1903 | `V1909 | `V2004 | `V20H2 | `V21H1
 ] [@@deriving sexp]
 (** All Windows 10 release versions. Ltsc and semi-annual releases are
    considered distincts. *)

--- a/src-opam/dockerfile_distro.mli
+++ b/src-opam/dockerfile_distro.mli
@@ -22,6 +22,13 @@
 
 (** {2 Known distributions and OCaml variants} *)
 
+type win10_release = [
+  | `V1507 | `Ltsc2015 | `V1511 | `V1607 | `Ltsc2016 | `V1703 | `V1709
+  | `V1803 | `V1809 | `Ltsc2019 | `V1903 | `V1909 | `V2004 | `V20H2
+] [@@deriving sexp]
+(** All Windows 10 release versions. Ltsc and semi-annual releases are
+   considered distincts. *)
+
 type t = [
   | `Alpine of [ `V3_3 | `V3_4 | `V3_5 | `V3_6 | `V3_7 | `V3_8 | `V3_9 | `V3_10 | `V3_11 | `V3_12 | `V3_13 | `Latest ]
   | `Archlinux of [ `Latest ]
@@ -31,8 +38,8 @@ type t = [
   | `OracleLinux of [ `V7 | `V8 | `Latest ]
   | `OpenSUSE of [ `V42_1 | `V42_2 | `V42_3 | `V15_0 | `V15_1 | `V15_2 | `Latest ]
   | `Ubuntu of [ `V12_04 | `V14_04 | `V15_04 | `V15_10 | `V16_04 | `V16_10 | `V17_04 | `V17_10 | `V18_04 | `V18_10 | `V19_04 | `V19_10 | `V20_04 | `V20_10 | `V21_04 | `LTS | `Latest ]
-  | `Cygwin of [ `V20H2 ]
-  | `Windows of [`Mingw | `Msvc] * [ `V1809 | `V1903 | `V1909 | `V2004 | `V20H2 ]
+  | `Cygwin of win10_release
+  | `Windows of [`Mingw | `Msvc] * win10_release
 ] [@@deriving sexp]
 (** Supported Docker container distributions *)
 
@@ -128,6 +135,14 @@ val base_distro_tag : ?arch:Ocaml_version.arch -> t -> string * string
  and other OCaml tool Dockerfiles. [arch] defaults to [x86_64] and can vary
  the base user/repository since some architecture are built elsewhere. *)
 
+val win10_release_to_string : win10_release -> string
+(** [win10_release update] converts a Windows 10 version name to
+   string. *)
+
+val win10_release_of_string : string -> win10_release option
+(** [win10_release_of_string] converts a Windows 10 version name as
+   string to its internal representation. *)
+
 (** {2 CPU architectures} *)
 
 val distro_arches : Ocaml_version.t -> t -> Ocaml_version.arch list
@@ -140,6 +155,14 @@ val distro_supported_on : Ocaml_version.arch -> Ocaml_version.t -> t -> bool
     on the distribution [distro]. *)
 
 (** {2 Opam build infrastructure support} *)
+
+type win10_release_status = [ `Deprecated | `Active ]
+(** Windows 10 release status. *)
+
+val win10_release_status : win10_release -> win10_release_status
+(* [win10_release_status v channel] returns the Microsoft support
+  status of the specified Windows 10 release.
+  @see <https://en.wikipedia.org/wiki/Windows_10_version_history#Channels> *)
 
 val active_distros : Ocaml_version.arch -> t list
 (** [active_distros arch] returns the list of currently supported

--- a/src-opam/dockerfile_distro.mli
+++ b/src-opam/dockerfile_distro.mli
@@ -26,8 +26,8 @@ type win10_release = [
   | `V1507 | `Ltsc2015 | `V1511 | `V1607 | `Ltsc2016 | `V1703 | `V1709
   | `V1803 | `V1809 | `Ltsc2019 | `V1903 | `V1909 | `V2004 | `V20H2 | `V21H1
 ] [@@deriving sexp]
-(** All Windows 10 release versions. Ltsc and semi-annual releases are
-   considered distincts. *)
+(** All Windows 10 release versions. LTSC versions are aliased to the
+   semi-annual release they're based on. *)
 
 type t = [
   | `Alpine of [ `V3_3 | `V3_4 | `V3_5 | `V3_6 | `V3_7 | `V3_8 | `V3_9 | `V3_10 | `V3_11 | `V3_12 | `V3_13 | `Latest ]

--- a/src-opam/dockerfile_windows.ml
+++ b/src-opam/dockerfile_windows.ml
@@ -154,13 +154,7 @@ module Winget = struct
   let winget = "winget-builder"
 
   let header ?(version=`V20H2) () =
-    let tag = match version with
-      | `V1809 -> "1809"
-      | `V1903 -> "1903"
-      | `V1909 -> "1909"
-      | `V2004 -> "2004"
-      | `V20H2 -> "20H2"
-    in
+    let tag = Dockerfile_distro.win10_release_to_string version in
     parser_directive (`Escape '`')
     @@ from ~alias:winget ~tag "mcr.microsoft.com/windows"
     @@ user "ContainerAdministrator"

--- a/src-opam/dockerfile_windows.ml
+++ b/src-opam/dockerfile_windows.ml
@@ -153,7 +153,7 @@ end
 module Winget = struct
   let winget = "winget-builder"
 
-  let header ?(version=`V20H2) () =
+  let header ?(version=Dockerfile_distro.win10_latest_image) () =
     let tag = Dockerfile_distro.win10_release_to_string version in
     parser_directive (`Escape '`')
     @@ from ~alias:winget ~tag "mcr.microsoft.com/windows"

--- a/src-opam/dockerfile_windows.mli
+++ b/src-opam/dockerfile_windows.mli
@@ -119,13 +119,13 @@ end
     @see <https://docs.microsoft.com/en-us/windows/package-manager/winget>/ *)
 module Winget : sig
   val build_from_source :
-    ?arch:Ocaml_version.arch -> ?version:[ `V1809 | `V1903 | `V1909 | `V2004 | `V20H2 ] ->
+    ?arch:Ocaml_version.arch -> ?version:Dockerfile_distro.win10_release ->
     ?winget_version:string -> ?vs_version:string -> unit -> t
   (** Build winget from source (in a separate Docker image). The
      optional [winget_version] specifies a Git reference. *)
 
   val install_from_release :
-    ?version:[ `V1809 | `V1903 | `V1909 | `V2004 | `V20H2 ] -> ?winget_version:string -> unit -> t
+    ?version:Dockerfile_distro.win10_release -> ?winget_version:string -> unit -> t
   (** Install winget from a released build (first in a separate Docker
      image). The optional [winget_version] specifies a Git tag. *)
 
@@ -137,7 +137,7 @@ module Winget : sig
   (** [install packages] will install the supplied winget package list. *)
 
   val dev_packages :
-    ?version:[ `V1809 | `V1903 | `V1909 | `V2004 | `V20H2 ] ->
+    ?version:Dockerfile_distro.win10_release ->
     ?extra:string list -> unit -> t
   (** [dev_packages ?version ?extra ()] will install the base development
      tools. Extra packages may also be optionally supplied via


### PR DESCRIPTION
This morning the Windows 21H1 update hit my laptop. It has not yet been published to Microsoft Docker repo, so we may want to wait before including this patch.