### PR TITLE
Update the opam 2.1 support to use the new 2.1 branch instead of master

### DIFF
--- a/src-opam/dockerfile_opam.ml
+++ b/src-opam/dockerfile_opam.ml
@@ -110,20 +110,20 @@ let header ?arch ?maintainer ?img ?tag d =
   @@ shell
 
 (* Apk based Dockerfile *)
-let apk_opam2 ?(labels=[]) ?arch ~hash_opam_2_0 ~hash_opam_master distro () =
+let apk_opam2 ?(labels=[]) ?arch ~hash_opam_2_0 ~hash_opam_2_1 distro () =
   let img, tag = D.base_distro_tag ?arch distro in
   header ?arch distro @@ label (("distro_style", "apk") :: labels)
   @@ Linux.Apk.install "build-base bzip2 git tar curl ca-certificates openssl"
   @@ Linux.Git.init ()
   @@ install_opam_from_source ~add_default_link:false ~branch:"2.0" ~hash:hash_opam_2_0 ()
-  @@ install_opam_from_source ~add_default_link:false ~enable_0install_solver:true ~branch:"master" ~hash:hash_opam_master ()
+  @@ install_opam_from_source ~add_default_link:false ~enable_0install_solver:true ~branch:"2.1" ~hash:hash_opam_2_1 ()
   @@ run "strip /usr/local/bin/opam*"
   @@ from ~tag img
   @@ Linux.Apk.add_repository ~tag:"edge" "https://dl-cdn.alpinelinux.org/alpine/edge/main"
   @@ Linux.Apk.add_repository ~tag:"edgecommunity" "https://dl-cdn.alpinelinux.org/alpine/edge/community"
   @@ Linux.Apk.add_repository ~tag:"testing" "https://dl-cdn.alpinelinux.org/alpine/edge/testing"
   @@ copy ~from:"0" ~src:["/usr/local/bin/opam-2.0"] ~dst:"/usr/bin/opam-2.0" ()
-  @@ copy ~from:"0" ~src:["/usr/local/bin/opam-master"] ~dst:"/usr/bin/opam-2.1" ()
+  @@ copy ~from:"0" ~src:["/usr/local/bin/opam-2.1"] ~dst:"/usr/bin/opam-2.1" ()
   @@ run "ln /usr/bin/opam-2.0 /usr/bin/opam"
   @@ Linux.Apk.dev_packages ()
   @@ Linux.Apk.add_user ~uid:1000 ~gid:1000 ~sudo:true "opam"
@@ -131,18 +131,18 @@ let apk_opam2 ?(labels=[]) ?arch ~hash_opam_2_0 ~hash_opam_master distro () =
 
 
 (* Debian based Dockerfile *)
-let apt_opam2 ?(labels=[]) ?arch distro ~hash_opam_2_0 ~hash_opam_master () =
+let apt_opam2 ?(labels=[]) ?arch distro ~hash_opam_2_0 ~hash_opam_2_1 () =
   let img, tag = D.base_distro_tag ?arch distro in
   header ?arch distro @@ label (("distro_style", "apt") :: labels)
   @@ Linux.Apt.install "build-essential curl git libcap-dev sudo"
   @@ Linux.Git.init ()
   @@ install_bubblewrap_from_source ()
   @@ install_opam_from_source ~add_default_link:false ~branch:"2.0" ~hash:hash_opam_2_0 ()
-  @@ install_opam_from_source ~add_default_link:false ~enable_0install_solver:true ~branch:"master" ~hash:hash_opam_master ()
+  @@ install_opam_from_source ~add_default_link:false ~enable_0install_solver:true ~branch:"2.1" ~hash:hash_opam_2_1 ()
   @@ from ~tag img
   @@ copy ~from:"0" ~src:["/usr/local/bin/bwrap"] ~dst:"/usr/bin/bwrap" ()
   @@ copy ~from:"0" ~src:["/usr/local/bin/opam-2.0"] ~dst:"/usr/bin/opam-2.0" ()
-  @@ copy ~from:"0" ~src:["/usr/local/bin/opam-master"] ~dst:"/usr/bin/opam-2.1" ()
+  @@ copy ~from:"0" ~src:["/usr/local/bin/opam-2.1"] ~dst:"/usr/bin/opam-2.1" ()
   @@ run "ln /usr/bin/opam-2.0 /usr/bin/opam"
   @@ run "ln -fs /usr/share/zoneinfo/Europe/London /etc/localtime"
   @@ Linux.Apt.dev_packages ()
@@ -158,7 +158,7 @@ let apt_opam2 ?(labels=[]) ?arch distro ~hash_opam_2_0 ~hash_opam_master () =
 
    [enable_powertools] enables the PowerTools repository on CentOS 8 and above.
    This is needed to get most of *-devel packages frequently used by opam packages. *)
-let yum_opam2 ?(labels= []) ?arch ~yum_workaround ~enable_powertools ~hash_opam_2_0 ~hash_opam_master distro () =
+let yum_opam2 ?(labels= []) ?arch ~yum_workaround ~enable_powertools ~hash_opam_2_0 ~hash_opam_2_1 distro () =
   let img, tag = D.base_distro_tag ?arch distro in
   let workaround =
     if yum_workaround then
@@ -174,7 +174,7 @@ let yum_opam2 ?(labels= []) ?arch ~yum_workaround ~enable_powertools ~hash_opam_
   @@ Linux.Git.init ()
   @@ install_bubblewrap_from_source ()
   @@ install_opam_from_source ~prefix:"/usr" ~add_default_link:false ~branch:"2.0" ~hash:hash_opam_2_0 ()
-  @@ install_opam_from_source ~prefix:"/usr" ~add_default_link:false ~enable_0install_solver:true ~branch:"master" ~hash:hash_opam_master ()
+  @@ install_opam_from_source ~prefix:"/usr" ~add_default_link:false ~enable_0install_solver:true ~branch:"2.1" ~hash:hash_opam_2_1 ()
   @@ from ~tag img
   @@ run "yum --version || dnf install -y yum"
   @@ workaround
@@ -183,7 +183,7 @@ let yum_opam2 ?(labels= []) ?arch ~yum_workaround ~enable_powertools ~hash_opam_
   @@ (if enable_powertools then run "yum config-manager --set-enabled powertools" @@ Linux.RPM.update else empty)
   @@ copy ~from:"0" ~src:["/usr/local/bin/bwrap"] ~dst:"/usr/bin/bwrap" ()
   @@ copy ~from:"0" ~src:["/usr/bin/opam-2.0"] ~dst:"/usr/bin/opam-2.0" ()
-  @@ copy ~from:"0" ~src:["/usr/bin/opam-master"] ~dst:"/usr/bin/opam-2.1" ()
+  @@ copy ~from:"0" ~src:["/usr/bin/opam-2.1"] ~dst:"/usr/bin/opam-2.1" ()
   @@ run "ln /usr/bin/opam-2.0 /usr/bin/opam"
   @@ run
        "sed -i.bak '/LC_TIME LC_ALL LANGUAGE/aDefaults    env_keep += \"OPAMYES OPAMJOBS OPAMVERBOSE\"' /etc/sudoers"
@@ -192,42 +192,42 @@ let yum_opam2 ?(labels= []) ?arch ~yum_workaround ~enable_powertools ~hash_opam_
 
 
 (* Zypper based Dockerfile *)
-let zypper_opam2 ?(labels=[]) ?arch ~hash_opam_2_0 ~hash_opam_master distro () =
+let zypper_opam2 ?(labels=[]) ?arch ~hash_opam_2_0 ~hash_opam_2_1 distro () =
   let img, tag = D.base_distro_tag ?arch distro in
   header ?arch distro @@ label (("distro_style", "zypper") :: labels)
   @@ Linux.Zypper.dev_packages ()
   @@ Linux.Git.init ()
   @@ install_bubblewrap_from_source ()
   @@ install_opam_from_source ~prefix:"/usr" ~add_default_link:false ~branch:"2.0" ~hash:hash_opam_2_0 ()
-  @@ install_opam_from_source ~prefix:"/usr" ~add_default_link:false ~enable_0install_solver:true ~branch:"master" ~hash:hash_opam_master ()
+  @@ install_opam_from_source ~prefix:"/usr" ~add_default_link:false ~enable_0install_solver:true ~branch:"2.1" ~hash:hash_opam_2_1 ()
   @@ from ~tag img
   @@ Linux.Zypper.dev_packages ()
   @@ copy ~from:"0" ~src:["/usr/local/bin/bwrap"] ~dst:"/usr/bin/bwrap" ()
   @@ copy ~from:"0" ~src:["/usr/bin/opam-2.0"] ~dst:"/usr/bin/opam-2.0" ()
-  @@ copy ~from:"0" ~src:["/usr/bin/opam-master"] ~dst:"/usr/bin/opam-2.1" ()
+  @@ copy ~from:"0" ~src:["/usr/bin/opam-2.1"] ~dst:"/usr/bin/opam-2.1" ()
   @@ run "ln /usr/bin/opam-2.0 /usr/bin/opam"
   @@ Linux.Zypper.add_user ~uid:1000 ~sudo:true "opam"
   @@ install_bubblewrap_wrappers @@ Linux.Git.init ()
 
 (* Pacman based Dockerfile *)
-let pacman_opam2 ?(labels=[]) ?arch ~hash_opam_2_0 ~hash_opam_master distro () =
+let pacman_opam2 ?(labels=[]) ?arch ~hash_opam_2_0 ~hash_opam_2_1 distro () =
   let img, tag = D.base_distro_tag ?arch distro in
   header ?arch distro @@ label (("distro_style", "pacman") :: labels)
   @@ Linux.Pacman.dev_packages ()
   @@ Linux.Git.init ()
   @@ install_opam_from_source ~add_default_link:false ~branch:"2.0" ~hash:hash_opam_2_0 ()
-  @@ install_opam_from_source ~add_default_link:false ~enable_0install_solver:true ~branch:"master" ~hash:hash_opam_master ()
+  @@ install_opam_from_source ~add_default_link:false ~enable_0install_solver:true ~branch:"2.1" ~hash:hash_opam_2_1 ()
   @@ run "strip /usr/local/bin/opam*"
   @@ from ~tag img
   @@ copy ~from:"0" ~src:["/usr/local/bin/opam-2.0"] ~dst:"/usr/bin/opam-2.0" ()
-  @@ copy ~from:"0" ~src:["/usr/local/bin/opam-master"] ~dst:"/usr/bin/opam-2.1" ()
+  @@ copy ~from:"0" ~src:["/usr/local/bin/opam-2.1"] ~dst:"/usr/bin/opam-2.1" ()
   @@ run "ln /usr/bin/opam-2.0 /usr/bin/opam"
   @@ Linux.Pacman.dev_packages ()
   @@ Linux.Pacman.add_user ~uid:1000 ~sudo:true "opam"
   @@ install_bubblewrap_wrappers @@ Linux.Git.init ()
 
 (* Cygwin based Dockerfile *)
-let cygwin_opam2 ?(labels=[]) ?arch ~hash_opam_2_0 ~hash_opam_master distro () =
+let cygwin_opam2 ?(labels=[]) ?arch ~hash_opam_2_0 ~hash_opam_2_1 distro () =
   let img, tag = D.base_distro_tag ?arch distro in
   let cyg = Windows.Cygwin.{ default with args = "--allow-test-packages" :: default.args } in
   header ?arch distro @@ label (("distro_style", "cygwin") :: labels)
@@ -235,18 +235,18 @@ let cygwin_opam2 ?(labels=[]) ?arch ~hash_opam_2_0 ~hash_opam_master distro () =
   @@ Windows.Cygwin.(setup ~cyg ~extra:(cygwin_packages ()) ())
   @@ Windows.Cygwin.Git.init ()
   @@ install_opam_from_source_cygwin ~add_default_link:false ~branch:"2.0" ~hash:hash_opam_2_0 ()
-  @@ install_opam_from_source_cygwin ~add_default_link:false ~enable_0install_solver:true ~branch:"master" ~hash:hash_opam_master ()
+  @@ install_opam_from_source_cygwin ~add_default_link:false ~enable_0install_solver:true ~branch:"2.1" ~hash:hash_opam_2_1 ()
   @@ run "strip /usr/local/bin/opam*"
   @@ from ~tag img
   @@ copy ~from:"0" ~src:["/usr/local/bin/opam-2.0"] ~dst:"/usr/bin/opam-2.0" ()
-  @@ copy ~from:"0" ~src:["/usr/local/bin/opam-master"] ~dst:"/usr/bin/opam-2.1" ()
+  @@ copy ~from:"0" ~src:["/usr/local/bin/opam-2.1"] ~dst:"/usr/bin/opam-2.1" ()
   @@ run "ln /usr/bin/opam-2.0 /usr/bin/opam"
   @@ Windows.Cygwin.(setup ~cyg ~extra:(cygwin_packages ()) ())
   @@ Windows.Cygwin.Git.init ()
 
 (* TODO: Compile opam-2.0 and 2.1 instead of downloading binaries,
    add an option to enable 0install-solver,
-   and pass ~hash_opam_2_0 ~hash_opam_master like the cygwin one *)
+   and pass ~hash_opam_2_0 ~hash_opam_2_1 like the cygwin one *)
 (* Native Windows, WinGet, Cygwin based Dockerfiles *)
 let windows_opam2 ?winget ?(labels=[]) ?arch distro () =
   let version = match distro with `Windows (_, v) -> v | _ -> assert false in
@@ -275,17 +275,17 @@ let windows_opam2 ?winget ?(labels=[]) ?arch distro () =
   @@ Windows.Cygwin.Git.init ()
   @@ Windows.cleanup ()
 
-let gen_opam2_distro ?winget ?(clone_opam_repo=true) ?arch ?labels ~hash_opam_2_0 ~hash_opam_master d =
+let gen_opam2_distro ?winget ?(clone_opam_repo=true) ?arch ?labels ~hash_opam_2_0 ~hash_opam_2_1 d =
   let fn = match D.package_manager d with
-  | `Apk -> apk_opam2 ?labels ?arch ~hash_opam_2_0 ~hash_opam_master d ()
-  | `Apt -> apt_opam2 ?labels ?arch ~hash_opam_2_0 ~hash_opam_master d ()
+  | `Apk -> apk_opam2 ?labels ?arch ~hash_opam_2_0 ~hash_opam_2_1 d ()
+  | `Apt -> apt_opam2 ?labels ?arch ~hash_opam_2_0 ~hash_opam_2_1 d ()
   | `Yum ->
      let yum_workaround = match d with `CentOS `V7 -> true | _ -> false in
      let enable_powertools = match d with `CentOS (`V6 | `V7) -> false | `CentOS _ -> true | _ -> false in
-     yum_opam2 ?labels ?arch ~yum_workaround ~enable_powertools ~hash_opam_2_0 ~hash_opam_master d ()
-  | `Zypper -> zypper_opam2 ?labels ?arch ~hash_opam_2_0 ~hash_opam_master d ()
-  | `Pacman -> pacman_opam2 ?labels ?arch ~hash_opam_2_0 ~hash_opam_master d ()
-  | `Cygwin -> cygwin_opam2 ?labels ?arch ~hash_opam_2_0 ~hash_opam_master d ()
+     yum_opam2 ?labels ?arch ~yum_workaround ~enable_powertools ~hash_opam_2_0 ~hash_opam_2_1 d ()
+  | `Zypper -> zypper_opam2 ?labels ?arch ~hash_opam_2_0 ~hash_opam_2_1 d ()
+  | `Pacman -> pacman_opam2 ?labels ?arch ~hash_opam_2_0 ~hash_opam_2_1 d ()
+  | `Cygwin -> cygwin_opam2 ?labels ?arch ~hash_opam_2_0 ~hash_opam_2_1 d ()
   | `Windows -> windows_opam2 ?winget ?labels ?arch d ()
   in
   let clone = if clone_opam_repo then

--- a/src-opam/dockerfile_opam.mli
+++ b/src-opam/dockerfile_opam.mli
@@ -29,8 +29,8 @@ val run_as_opam : ('a, unit, string, Dockerfile.t) format4 -> 'a
 val install_opam_from_source : ?add_default_link:bool ->
   ?prefix:string -> ?enable_0install_solver:bool -> branch:string -> hash:string -> unit -> Dockerfile.t
 (** Commands to install OPAM via a source code checkout from GitHub.
-    The [branch] can be a git tag or branch (e.g. [2.0] for opam 2.x or [master] for
-    the latest trunk version).
+    The [branch] can be a git tag or branch (e.g. [2.0] for opam 2.0.x or [2.1] for
+    the opam 2.1.x).
     The binaries are installed under [<prefix>/bin/opam-<branch>],
     defaulting to [/usr/local/bin].
     If [add_default_link] is true (the default), then the [opam-<branch>]
@@ -45,11 +45,11 @@ val gen_opam2_distro :
   ?arch:Ocaml_version.arch ->
   ?labels:(string * string) list ->
   hash_opam_2_0:string ->
-  hash_opam_master:string ->
+  hash_opam_2_1:string ->
   Dockerfile_distro.t
   -> string * Dockerfile.t
-(** [gen_opam2_distro ~hash_opam_2_0 ~hash_opam_master d] will generate a Dockerfile
-   for Linux distribution [d] with opam 2.0 and opam master, per hash given in parameter.
+(** [gen_opam2_distro ~hash_opam_2_0 ~hash_opam_2_1 d] will generate a Dockerfile
+   for Linux distribution [d] with opam 2.0 and opam 2.1, per hash given in parameter.
    @return a tuple of the Docker tag and the Dockerfile.
    If [clone_opam_repo] is true (the default) then the Dockerfile will also git
    clone the official opam-repository into [/home/opam/opam-repository].


### PR DESCRIPTION
opam 2.1 just branched from master so this PR is here to update dockerfile-opam to use this new branch instead of master