### PR TITLE
Winget fixes

### DIFF
--- a/src-opam/dockerfile_opam.ml
+++ b/src-opam/dockerfile_opam.ml
@@ -251,8 +251,8 @@ let cygwin_opam2 ?(labels=[]) ?arch ~hash_opam_2_0 ~hash_opam_2_1 distro () =
 let windows_opam2 ?winget ?(labels=[]) ?arch distro () =
   let version = match distro with `Windows (_, v) -> v | _ -> assert false in
   (match winget with
-  | None -> Windows.Winget.install_from_release ~version ()
-  | Some _ -> empty)
+  | None when Windows.Winget.is_supported version -> Windows.Winget.install_from_release ~version ()
+  | _ -> empty)
   @@ header ?arch distro @@ label (("distro_style", "windows") :: labels)
   @@ user "ContainerAdministrator"
   @@ begin
@@ -270,8 +270,10 @@ let windows_opam2 ?winget ?(labels=[]) ?arch distro () =
       Windows.install_vc_redist () @@ t
       @@ Windows.Cygwin.setup ~extra () @@ t'
     end
-  @@ Windows.Winget.setup ?from:winget ()
-  @@ Windows.Winget.dev_packages ~version ()
+  @@ begin if Windows.Winget.is_supported version then
+      Windows.Winget.setup ?from:winget ()
+      @@ Windows.Winget.dev_packages ~version ()
+    else empty end
   @@ Windows.Cygwin.Git.init ()
   @@ Windows.cleanup ()
 

--- a/src-opam/dockerfile_windows.ml
+++ b/src-opam/dockerfile_windows.ml
@@ -189,14 +189,14 @@ module Winget = struct
     let src =
       let src = "https://github.com/microsoft/winget-cli/releases/" in
       match winget_version with
-      | None -> src ^ "latest/download/" ^ file ^ "appxbundle"
-      | Some ver -> src ^ "download/" ^ ver ^ "/" ^ file ^ "appxbundle"
+      | None -> src ^ "latest/download/" ^ file ^ "msixbundle"
+      | Some ver -> src ^ "download/" ^ ver ^ "/" ^ file ^ "msixbundle"
     in
     let dst = {|C:\TEMP\|} ^ file ^ "zip" in
     header ?version ()
     @@ add ~src:[src] ~dst ()
     @@ run_powershell {|Expand-Archive -LiteralPath %s -DestinationPath C:\TEMP\winget-cli -Force|} dst
-    @@ run {|ren C:\TEMP\winget-cli\AppInstaller_x64.appx AppInstaller_x64.zip|}
+    @@ run {|ren C:\TEMP\winget-cli\AppInstaller_x64.msix AppInstaller_x64.zip|}
     @@ run_powershell {|Expand-Archive -LiteralPath C:\TEMP\winget-cli\AppInstaller_x64.zip -DestinationPath C:\TEMP\winget-cli\ -Force|}
     @@ footer ""
 

--- a/src-opam/dockerfile_windows.ml
+++ b/src-opam/dockerfile_windows.ml
@@ -151,6 +151,9 @@ module Cygwin = struct
 end
 
 module Winget = struct
+  let is_supported version =
+    not (List.mem version [`V1507; `Ltsc2015; `V1511; `V1607; `Ltsc2016; `V1703; `V1709; `V1803])
+
   let winget = "winget-builder"
 
   let header ?(version=Dockerfile_distro.win10_latest_image) () =

--- a/src-opam/dockerfile_windows.mli
+++ b/src-opam/dockerfile_windows.mli
@@ -118,6 +118,11 @@ end
 (** Rules for winget installation.
     @see <https://docs.microsoft.com/en-us/windows/package-manager/winget>/ *)
 module Winget : sig
+  val is_supported : Dockerfile_distro.win10_release -> bool
+  (** Winget 1.0.11692 discontinued support for versions older than
+     Windows 10 1809. Older versions of Winget have bugs, don't use
+     them. *)
+
   val build_from_source :
     ?arch:Ocaml_version.arch -> ?version:Dockerfile_distro.win10_release ->
     ?winget_version:string -> ?vs_version:string -> unit -> t


### PR DESCRIPTION
Microsoft changed the release format of Winget and discontinued support for versions of Windows older than Windows 10 1809, so I disabled Winget entirely on these systems (previous versions of Winget are buggy anyway...).