### PR TITLE
Add support for Windows 10 Latest Cumulative Update tags

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ dev
 - Introduce a Cygwin image, and move Windows Mingw and Windows Msvc at
   the distro level. (@MisterDA #42)
 - Add edge and edgecommunity repositories to the Alpine image (@EwanMellor #48)
+- Add support for Windows 10 Latest Cumulative Update docker image tags (@dra27 #56)
 
 v7.1.0 2021-02-25 Cambridge
 ---------------------------

--- a/src-opam/dockerfile_distro.mli
+++ b/src-opam/dockerfile_distro.mli
@@ -29,6 +29,22 @@ type win10_release = [
 (** All Windows 10 release versions. LTSC versions are aliased to the
    semi-annual release they're based on. *)
 
+type win10_lcu = [
+  | `LCU
+  | `LCU20210713
+  | `LCU20210608
+] [@@deriving sexp]
+(** Windows 10 Latest Cumulative Update. Out-of-band LCUs are not included
+    as they aren't released with Docker images. [`LCU] always refers to the
+    most recent LCU. *)
+
+val win10_current_lcu : win10_lcu
+(** Current Windows 10 Latest Cumulative Update; value used when [`LCU] is
+    specified. *)
+
+type win10_revision = win10_release * win10_lcu option [@@deriving sexp]
+(** A Windows 10 version optionally with an LCU. *)
+
 type t = [
   | `Alpine of [ `V3_3 | `V3_4 | `V3_5 | `V3_6 | `V3_7 | `V3_8 | `V3_9 | `V3_10 | `V3_11 | `V3_12 | `V3_13 | `Latest ]
   | `Archlinux of [ `Latest ]
@@ -135,7 +151,7 @@ val latest_tag_of_distro : t -> string
   regularly rewritten to point to any new releases of the
   distribution. *)
 
-val base_distro_tag : ?arch:Ocaml_version.arch -> t -> string * string
+val base_distro_tag : ?win10_revision:win10_lcu -> ?arch:Ocaml_version.arch -> t -> string * string
 (** [base_distro_tag ?arch t] will return a tuple of a Docker Hub
  user/repository and tag for which the base image of a distribution
  can be found (e.g. [opensuse/leap],[15.0] which maps to [opensuse/leap:15.0]
@@ -144,12 +160,16 @@ val base_distro_tag : ?arch:Ocaml_version.arch -> t -> string * string
  the base user/repository since some architecture are built elsewhere. *)
 
 val win10_release_to_string : win10_release -> string
-(** [win10_release update] converts a Windows 10 version name to
+(** [win10_release_to_string update] converts a Windows 10 version name to
    string. *)
 
 val win10_release_of_string : string -> win10_release option
 (** [win10_release_of_string] converts a Windows 10 version name as
-   string to its internal representation. *)
+   string to its internal representation. Ignores any KB number. *)
+
+val win10_revision_to_string : win10_revision -> string
+
+val win10_revision_of_string : string -> win10_revision option
 
 (** {2 CPU architectures} *)
 

--- a/src-opam/dockerfile_opam.mli
+++ b/src-opam/dockerfile_opam.mli
@@ -40,6 +40,7 @@ val install_opam_from_source : ?add_default_link:bool ->
     solver should be accessible in the resulting opam binary. *)
 
 val gen_opam2_distro :
+  ?win10_revision:Dockerfile_distro.win10_lcu ->
   ?winget:string ->
   ?clone_opam_repo:bool ->
   ?arch:Ocaml_version.arch ->

--- a/src-opam/dockerfile_windows.mli
+++ b/src-opam/dockerfile_windows.mli
@@ -124,12 +124,14 @@ module Winget : sig
      them. *)
 
   val build_from_source :
-    ?arch:Ocaml_version.arch -> ?version:Dockerfile_distro.win10_release ->
+    ?arch:Ocaml_version.arch -> ?win10_revision:Dockerfile_distro.win10_lcu ->
+    ?version:Dockerfile_distro.win10_release ->
     ?winget_version:string -> ?vs_version:string -> unit -> t
   (** Build winget from source (in a separate Docker image). The
      optional [winget_version] specifies a Git reference. *)
 
   val install_from_release :
+    ?win10_revision:Dockerfile_distro.win10_lcu ->
     ?version:Dockerfile_distro.win10_release -> ?winget_version:string -> unit -> t
   (** Install winget from a released build (first in a separate Docker
      image). The optional [winget_version] specifies a Git tag. *)


### PR DESCRIPTION
Windows Containers cannot start an image for a newer version of Windows and shouldn't attempt to start a container with a newer LCU (although the container should physically start).

On the second Wednesday of the month, `mcr.microsoft.com/windows:20H2`, etc. will all point to the LCU released the previous evening. The base-images should not immediately start pulling that until the workers have been updated - I think it's better therefore to refer to `mcr.microsoft.com/windows:20H2-KB5003637` (which is the 8 June 2021 LCU) which will always pull the same image. Once the workers are updated, we update the base-images builder with the new LCU tag.

This adds support for appending the KB number for the LCU for a given month. Microsoft only release Docker images for the official "update Tuesday" LCU, and not any out-of-band LCUs, so the OOB LCUs are not included. Since the KB number can differ by version, the LCU is exposed as a date and is then mapped when given a Windows 10 release to a KB number to append to the tag.

I've "structured" this so that the LCU gets added as the tag is being generated - i.e. it's not part of the Windows 10 version. While the different releases of Windows 10 are distinct (and we'll always want to support multiple releases at once) I cannot see the sense in supporting multiple LCUs.