### PR TITLE
Ensure stray double-quotes don't get into PATH

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
+unreleased
+----------
+
+- Ensure stray double-quotes don't end up in PATH on Windows images (@dra27 #62)
+- Stop pinning binutils to 2.35 in Windows builds as that no longer works with
+  GCC 11. (@dra27 #61)
+
+
 v7.2.0 2021-07-28 Cambridge
---------------------------
+---------------------------
 
 - Add support for S390x architecture builds for Debian (@avsm)
 - Add OpenSUSE 15.3 (#53 @avsm)

--- a/src-opam/dockerfile_opam.ml
+++ b/src-opam/dockerfile_opam.ml
@@ -268,6 +268,7 @@ let windows_opam2 ?win10_revision ?winget ?(labels=[]) ?arch distro () =
       in
       let extra, t' = Windows.Cygwin.ocaml_for_windows_packages ~extra () in
       Windows.install_vc_redist () @@ t
+      @@ Windows.sanitize_reg_path ()
       @@ Windows.Cygwin.setup ~extra () @@ t'
     end
   @@ begin if Windows.Winget.is_supported version then

--- a/src-opam/dockerfile_windows.ml
+++ b/src-opam/dockerfile_windows.ml
@@ -50,6 +50,11 @@ let install_visual_studio_build_tools ?(vs_version="16") components =
   @@ add ~src:["https://aka.ms/vs/" ^ vs_version ^ "/release/vs_buildtools.exe"] ~dst:{|C:\TEMP\vs_buildtools.exe|} ()
   @@ install
 
+let sanitize_reg_path () =
+  run {|for /f "tokens=1,2,*" %%a in ('reg query "HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment" /V Path ^| findstr /r "\\$"') do `
+          for /f "delims=" %%l in ('cmd /v:on /c "set v=%%c&& echo !v:~0,-1!"') do `
+            reg add "HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment" /V Path /t REG_EXPAND_SZ /f /d "%%l"|}
+
 let prepend_path paths =
   let paths = String.concat ";" paths in
   run {|for /f "tokens=1,2,*" %%a in ('reg query "HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment" /V Path ^| findstr /r "^[^H]"') do `

--- a/src-opam/dockerfile_windows.mli
+++ b/src-opam/dockerfile_windows.mli
@@ -33,6 +33,11 @@ val run_ocaml_env : string list -> ('a, unit, string, t) format4 -> 'a
 (** [run_ocaml_env args fmt] will execute [fmt] in the evironment
    loaded by [ocaml-env exec] with [args]. *)
 
+val sanitize_reg_path : unit -> t
+(** [sanitize_reg_path ()] adds the command necessary to remove a trailing
+    backaslash from the Path value stored in the registry and must be called
+    before any further manipulation of this variable is done by Dockerfile. *)
+
 val install_vc_redist : ?vs_version:string -> unit -> t
 (** Install Microsoft Visual C++ Redistributable.
    @see <https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads> *)


### PR DESCRIPTION
If the registry value for Path ends with a backslash than `\"` ends up in a command line which is interpreted as a double-quote character by the somewhat messed up rules of command line parsing in Windows! The "simplest" fix is to ensure this never happens. The actual fix would be to add an extra backslash to the end of command lines when there's an odd number of terminating backslashes - but try doing that before you've got `sed`!