### PR TITLE
Introduce Windows 10 LTSC 2022 and Windows Server image

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@ unreleased
 - Ensure stray double-quotes don't end up in PATH on Windows images (@dra27 #62)
 - Stop pinning binutils to 2.35 in Windows builds as that no longer works with
   GCC 11. (@dra27 #61)
-
+- Introduce Windows 10 LTSC 2022 and Windows Server image (@MisterDA #63)
 
 v7.2.0 2021-07-28 Cambridge
 ---------------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@ unreleased
 - Stop pinning binutils to 2.35 in Windows builds as that no longer works with
   GCC 11. (@dra27 #61)
 - Introduce Windows 10 LTSC 2022 and Windows Server image (@MisterDA #63)
+- Expose `Dockerfile_distro.win10_docker_base_image` and
+  `Dockerfile_distro.win10_base_tag` to get the Windows container base
+  image and tags. (@MisterDA #63)
 
 v7.2.0 2021-07-28 Cambridge
 ---------------------------

--- a/src-opam/dockerfile_distro.ml
+++ b/src-opam/dockerfile_distro.ml
@@ -34,7 +34,7 @@ let win10_current_lcu = `LCU20210914
 
 type win10_revision = win10_release * win10_lcu option [@@deriving sexp]
 
-let win10_lcus = [
+let win10_lcus : ('a * int * win10_release list) list = [
   `LCU20210914, 5005575, [`Ltsc2022];
   `LCU20210914, 5005565, [`V2004; `V20H2; `V21H1];
   `LCU20210914, 5005566, [`V1909];
@@ -59,7 +59,7 @@ let win10_lcus = [
   `LCU20210608, 5003687, [`V1507; `Ltsc2015];
 ]
 
-let win10_lcu_to_kb =
+let win10_lcu_to_kb : ((win10_lcu * win10_release), int option) Hashtbl.t =
   let t = Hashtbl.create 63 in
   let f (lcu, kb, vs) =
     let g v =
@@ -79,7 +79,7 @@ let win10_lcu_kb_number v lcu =
   try Hashtbl.find win10_lcu_to_kb (lcu, v)
   with Not_found -> None
 
-let win10_kb_number_to_lcu v kb =
+let win10_kb_number_to_lcu (v:win10_release) kb =
   match Hashtbl.find win10_kb_to_lcu (kb, v) with
   | lcu -> Some (v, lcu)
   | exception Not_found -> None
@@ -385,7 +385,7 @@ let rec win10_revision_to_string = function
 | (v, Some lcu) ->
     match win10_lcu_kb_number v lcu with
     | Some kb -> Printf.sprintf "%s-KB%d" (win10_release_to_string v) kb
-    | None -> invalid_arg "No KB for this Win10 revision"
+    | None -> Fmt.invalid_arg "No KB for this Win10 %s revision" (win10_release_to_string v)
 
 let win10_revision_of_string v =
   let v, lcu =

--- a/src-opam/dockerfile_distro.ml
+++ b/src-opam/dockerfile_distro.ml
@@ -676,6 +676,14 @@ let package_manager (t:t) =
   |`Cygwin _ -> `Cygwin
   |`Windows _ -> `Windows
 
+let win10_base_tag ?win10_revision (base:win10_docker_base_image) v =
+  let base = match base with
+    | `NanoServer -> "mcr.microsoft.com/windows/nanoserver"
+    | `ServerCore -> "mcr.microsoft.com/windows/servercore"
+    | `Windows when v = `Ltsc2022 -> "mcr.microsoft.com/windows/server"
+    | `Windows -> "mcr.microsoft.com/windows" in
+  base, win10_revision_to_string (v, win10_revision)
+
 let base_distro_tag ?win10_revision ?(arch=`X86_64) d =
   match resolve_alias d with
   | `Alpine v -> begin
@@ -784,13 +792,9 @@ let base_distro_tag ?win10_revision ?(arch=`X86_64) d =
       in
       "opensuse/leap", tag
   | `Cygwin (`Ltsc2015 | `Ltsc2016 | `Ltsc2019) -> assert false
-  | `Cygwin v ->
-     "mcr.microsoft.com/windows/servercore", win10_revision_to_string (v, win10_revision)
+  | `Cygwin v -> win10_base_tag ?win10_revision `ServerCore v
   | `Windows (_, (`Ltsc2015 | `Ltsc2016 | `Ltsc2019)) -> assert false
-  | `Windows (_, (`Ltsc2022 as v)) ->
-    "mcr.microsoft.com/windows/server", win10_revision_to_string (v, win10_revision)
-  | `Windows (_, v) ->
-     "mcr.microsoft.com/windows", win10_revision_to_string (v, win10_revision)
+  | `Windows (_, v) -> win10_base_tag ?win10_revision `Windows v
 
 let compare a b =
   String.compare (human_readable_string_of_distro a) (human_readable_string_of_distro b)

--- a/src-opam/dockerfile_distro.mli
+++ b/src-opam/dockerfile_distro.mli
@@ -25,6 +25,7 @@
 type win10_release = [
   | `V1507 | `Ltsc2015 | `V1511 | `V1607 | `Ltsc2016 | `V1703 | `V1709
   | `V1803 | `V1809 | `Ltsc2019 | `V1903 | `V1909 | `V2004 | `V20H2 | `V21H1
+  | `Ltsc2022
 ] [@@deriving sexp]
 (** All Windows 10 release versions. LTSC versions are aliased to the
    semi-annual release they're based on. *)

--- a/src-opam/dockerfile_distro.mli
+++ b/src-opam/dockerfile_distro.mli
@@ -154,6 +154,22 @@ val latest_tag_of_distro : t -> string
   regularly rewritten to point to any new releases of the
   distribution. *)
 
+type win10_docker_base_image = [
+  | `NanoServer (** Windows Nano Server *)
+  | `ServerCore (** Windows Server Core *)
+  | `Windows    (** Windows Server "with Desktop Experience" *)
+]
+(** Windows containers base images.
+    @see <https://docs.microsoft.com/en-us/virtualization/windowscontainers/manage-containers/container-base-images> *)
+
+val win10_base_tag : ?win10_revision:win10_lcu -> win10_docker_base_image -> win10_release -> string * string
+(** [win10_base_tag base_image release] will return a tuple of Windows
+   container base image and tag for which the base image of a Windows
+   base image can be found (e.g.
+   [mcr.microsoft.com/windows/servercore],[ltsc2022] which maps to
+   [mcr.microsoft.com/windows/servercore:ltsc2022] on the Microsoft
+   Container Registry). *)
+
 val base_distro_tag : ?win10_revision:win10_lcu -> ?arch:Ocaml_version.arch -> t -> string * string
 (** [base_distro_tag ?arch t] will return a tuple of a Docker Hub
  user/repository and tag for which the base image of a distribution

--- a/src-opam/dockerfile_windows.ml
+++ b/src-opam/dockerfile_windows.ml
@@ -159,9 +159,9 @@ module Winget = struct
   let winget = "winget-builder"
 
   let header ?win10_revision ?(version=Dockerfile_distro.win10_latest_image) () =
-    let tag = Dockerfile_distro.win10_revision_to_string (version, win10_revision) in
+    let img, tag = Dockerfile_distro.win10_base_tag ?win10_revision `Windows version in
     parser_directive (`Escape '`')
-    @@ from ~alias:winget ~tag "mcr.microsoft.com/windows"
+    @@ from ~alias:winget ~tag img
     @@ user "ContainerAdministrator"
 
   let footer path =

--- a/src-opam/dockerfile_windows.ml
+++ b/src-opam/dockerfile_windows.ml
@@ -217,13 +217,13 @@ module Winget = struct
         winget settings|}
 
   let install pkgs =
-    List.fold_left (fun acc pkg -> acc @@ run "winget install %s" pkg) empty pkgs
+    List.fold_left (fun acc pkg -> acc @@ run "winget install --exact --accept-source-agreements --accept-package-agreements %s" pkg) empty pkgs
 
   let dev_packages ?version ?extra () =
     match version with
     (* 2021-04-01: Installing git fails with exit-code 2316632065. *)
     | Some `V1809 -> maybe install extra
-    | _ -> install ["git"] @@ maybe install extra
+    | _ -> install ["Git.Git"] @@ maybe install extra
 
   module Git = struct
     let init ?(name="Docker") ?(email="docker@example.com") () =


### PR DESCRIPTION
LTSC is a bit weird: it's not exactly an alias to 21H1, and 21H1
hasn't been released yet. For now, let's consider that they are
independent releases and that 21H1 isn't yet available.

Also introduce the "windows/server" image that replaces the "windows"
image starting with ltsc2022.