### PR TITLE
distro updates for alpine 3.14/ubuntu 21.10 and refresh

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,12 @@
 unreleased
 ----------
 
+- Add Alpine 3.14 and Ubuntu 21.10 (@avsm)
+- Move Fedora 33 and OpenSUSE 15.2 to deprecated and Alpine 3.13 to Tier 2. (@avsm)
+- Latest Fedora is now Fedora 34 (@avsm)
 - Asssume Windows x64 is an active distro even when it doesn't have the latest
   release (@dra27 #66; #68)
+- Latest base distro is now Debian 11 (from Debian 10) (@kit-ty-kate #59)
 - Ensure stray double-quotes don't end up in PATH on Windows images (@dra27 #62)
 - Stop pinning binutils to 2.35 in Windows builds as that no longer works with
   GCC 11. (@dra27 #61)

--- a/src-opam/dockerfile_distro.ml
+++ b/src-opam/dockerfile_distro.ml
@@ -77,14 +77,14 @@ let win10_kb_number_to_lcu v kb =
   | exception Not_found -> None
 
 type t = [
-  | `Alpine of [ `V3_3 | `V3_4 | `V3_5 | `V3_6 | `V3_7 | `V3_8 | `V3_9 | `V3_10 | `V3_11 | `V3_12 | `V3_13 | `Latest ]
+  | `Alpine of [ `V3_3 | `V3_4 | `V3_5 | `V3_6 | `V3_7 | `V3_8 | `V3_9 | `V3_10 | `V3_11 | `V3_12 | `V3_13 | `V3_14 | `Latest ]
   | `Archlinux of [ `Latest ]
   | `CentOS of [ `V6 | `V7 | `V8 | `Latest ]
   | `Debian of [ `V11 | `V10 | `V9 | `V8 | `V7 | `Stable | `Testing | `Unstable ]
   | `Fedora of [ `V21 | `V22 | `V23 | `V24 | `V25 | `V26 | `V27 | `V28 | `V29 | `V30 | `V31 | `V32 | `V33 | `V34 | `Latest ]
   | `OracleLinux of [ `V7 | `V8 | `Latest ]
   | `OpenSUSE of [ `V42_1 | `V42_2 | `V42_3 | `V15_0 | `V15_1 | `V15_2 | `V15_3 | `Latest ]
-  | `Ubuntu of [ `V12_04 | `V14_04 | `V15_04 | `V15_10 | `V16_04 | `V16_10 | `V17_04 | `V17_10 | `V18_04 | `V18_10 | `V19_04 | `V19_10 | `V20_04 | `V20_10 | `V21_04 | `LTS | `Latest ]
+  | `Ubuntu of [ `V12_04 | `V14_04 | `V15_04 | `V15_10 | `V16_04 | `V16_10 | `V17_04 | `V17_10 | `V18_04 | `V18_10 | `V19_04 | `V19_10 | `V20_04 | `V20_10 | `V21_04 | `V21_10 | `LTS | `Latest ]
   | `Cygwin of win10_release
   | `Windows of [`Mingw | `Msvc] * win10_release
 ] [@@deriving sexp]
@@ -122,7 +122,7 @@ type status = [
 ] [@@deriving sexp]
 
 let distros : t list = [
-  `Alpine `V3_3; `Alpine `V3_4; `Alpine `V3_5; `Alpine `V3_6; `Alpine `V3_7; `Alpine `V3_8; `Alpine `V3_9; `Alpine `V3_10; `Alpine `V3_11; `Alpine `V3_12; `Alpine `V3_13; `Alpine `Latest;
+  `Alpine `V3_3; `Alpine `V3_4; `Alpine `V3_5; `Alpine `V3_6; `Alpine `V3_7; `Alpine `V3_8; `Alpine `V3_9; `Alpine `V3_10; `Alpine `V3_11; `Alpine `V3_12; `Alpine `V3_13; `Alpine `V3_14; `Alpine `Latest;
   `Archlinux `Latest;
   `CentOS `V6; `CentOS `V7; `CentOS `V8; `CentOS `Latest;
   `Debian `V11; `Debian `V10; `Debian `V9; `Debian `V8; `Debian `V7;
@@ -131,7 +131,7 @@ let distros : t list = [
   `OracleLinux `V7; `OracleLinux `V8; `OracleLinux `Latest;
   `OpenSUSE `V42_1; `OpenSUSE `V42_2; `OpenSUSE `V42_3; `OpenSUSE `V15_0; `OpenSUSE `V15_1; `OpenSUSE `V15_2; `OpenSUSE `V15_3; `OpenSUSE `Latest;
   `Ubuntu `V12_04; `Ubuntu `V14_04; `Ubuntu `V15_04; `Ubuntu `V15_10;
-  `Ubuntu `V16_04; `Ubuntu `V16_10; `Ubuntu `V17_04; `Ubuntu `V17_10; `Ubuntu `V18_04; `Ubuntu `V18_10; `Ubuntu `V19_04; `Ubuntu `V19_10; `Ubuntu `V20_04; `Ubuntu `V20_10; `Ubuntu `V21_04;
+  `Ubuntu `V16_04; `Ubuntu `V16_10; `Ubuntu `V17_04; `Ubuntu `V17_10; `Ubuntu `V18_04; `Ubuntu `V18_10; `Ubuntu `V19_04; `Ubuntu `V19_10; `Ubuntu `V20_04; `Ubuntu `V20_10; `Ubuntu `V21_04; `Ubuntu `V21_10;
   `Ubuntu `Latest; `Ubuntu `LTS;
 ]
 let distros =
@@ -183,8 +183,9 @@ let win10_latest_image = `V20H2
 
 let distro_status (d:t) : status = match d with
   | `Alpine (`V3_3 | `V3_4 | `V3_5 | `V3_6 | `V3_7 | `V3_8 | `V3_9 | `V3_10 | `V3_11 | `V3_12) -> `Deprecated
-  | `Alpine `V3_13 -> `Active `Tier1
-  | `Alpine `Latest -> `Alias (`Alpine `V3_13)
+  | `Alpine `V3_13 -> `Active `Tier2
+  | `Alpine `V3_14 -> `Active `Tier1
+  | `Alpine `Latest -> `Alias (`Alpine `V3_14)
   | `Archlinux `Latest -> `Active `Tier3
   | `CentOS `V8 -> `Active `Tier2
   | `CentOS `V7 -> `Active `Tier3
@@ -196,17 +197,16 @@ let distro_status (d:t) : status = match d with
   | `Debian `Stable -> `Alias (`Debian `V11)
   | `Debian `Testing -> `Active `Tier3
   | `Debian `Unstable -> `Active `Tier3
-  | `Fedora ( `V21 | `V22 | `V23 | `V24 | `V25 | `V26 | `V27 | `V28 | `V29 | `V30 | `V31 | `V32) -> `Deprecated
-  | `Fedora `V33 -> `Active `Tier2
+  | `Fedora ( `V21 | `V22 | `V23 | `V24 | `V25 | `V26 | `V27 | `V28 | `V29 | `V30 | `V31 | `V32 | `V33) -> `Deprecated
   | `Fedora `V34 -> `Active `Tier2
-  | `Fedora `Latest -> `Alias (`Fedora `V33)
+  | `Fedora `Latest -> `Alias (`Fedora `V34)
   | `OracleLinux (`V7|`V8) -> `Active `Tier3
   | `OracleLinux `Latest -> `Alias (`OracleLinux `V8)
-  | `OpenSUSE (`V42_1 | `V42_2 | `V42_3 | `V15_0 | `V15_1) -> `Deprecated
-  | `OpenSUSE (`V15_2 | `V15_3) -> `Active `Tier2
+  | `OpenSUSE (`V42_1 | `V42_2 | `V42_3 | `V15_0 | `V15_1 | `V15_2) -> `Deprecated
+  | `OpenSUSE `V15_3 -> `Active `Tier2
   | `OpenSUSE `Latest -> `Alias (`OpenSUSE `V15_3)
   | `Ubuntu (`V18_04) -> `Active `Tier3
-  | `Ubuntu (`V20_04 | `V21_04) -> `Active `Tier2
+  | `Ubuntu (`V20_04 | `V21_04 |`V21_10) -> `Active `Tier2
   | `Ubuntu ( `V12_04 | `V14_04 | `V15_04 | `V15_10 | `V16_04 | `V16_10 | `V17_04 | `V17_10 | `V18_10 | `V19_04 | `V19_10 | `V20_10) -> `Deprecated
   | `Ubuntu `LTS -> `Alias (`Ubuntu `V20_04)
   | `Ubuntu `Latest -> `Alias (`Ubuntu `V21_04)
@@ -245,8 +245,8 @@ let distro_arches ov (d:t) =
   | `Debian `V11, ov when OV.(compare Releases.v4_05_0 ov) = -1 -> [ `I386; `X86_64; `Aarch64; `Ppc64le; `Aarch32; `S390x ]
   | `Debian `V10, ov when OV.(compare Releases.v4_05_0 ov) = -1 -> [ `I386; `X86_64; `Aarch64; `Ppc64le; `Aarch32; `S390x ]
   | `Debian `V9, ov when OV.(compare Releases.v4_05_0 ov) = -1 -> [ `I386; `X86_64; `Aarch64; `Aarch32 ]
-  | `Alpine (`V3_6 | `V3_7 | `V3_8 | `V3_9 | `V3_10 | `V3_11 | `V3_12 | `V3_13), ov when OV.(compare Releases.v4_05_0 ov) = -1 -> [ `X86_64; `Aarch64 ]
-  | `Ubuntu (`V18_04|`V20_04|`V20_10|`V21_04), ov when OV.(compare Releases.v4_05_0 ov) = -1  -> [ `X86_64; `Aarch64; `Ppc64le ]
+  | `Alpine (`V3_6 | `V3_7 | `V3_8 | `V3_9 | `V3_10 | `V3_11 | `V3_12 | `V3_13 |`V3_14), ov when OV.(compare Releases.v4_05_0 ov) = -1 -> [ `X86_64; `Aarch64 ]
+  | `Ubuntu (`V18_04|`V20_04|`V20_10|`V21_04 |`V21_10), ov when OV.(compare Releases.v4_05_0 ov) = -1  -> [ `X86_64; `Aarch64; `Ppc64le ]
   | `Fedora (`V33|`V34), ov when OV.(compare Releases.v4_08_0 ov) = -1  -> [ `X86_64; `Aarch64 ]
   (* 2021-04-19: should be 4.03 but there's a linking failure until 4.06. *)
   | `Windows (`Msvc, _), ov when OV.(compare Releases.v4_06_0 ov) = 1 -> []
@@ -300,6 +300,7 @@ let builtin_ocaml_of_distro (d:t) : string option =
   |`Ubuntu `V20_04 -> Some "4.08.1"
   |`Ubuntu `V20_10 -> Some "4.08.1"
   |`Ubuntu `V21_04 -> Some "4.11.1"
+  |`Ubuntu `V21_10 -> Some "4.11.1"
   |`Alpine `V3_3 -> Some "4.02.3"
   |`Alpine `V3_4 -> Some "4.02.3"
   |`Alpine `V3_5 -> Some "4.04.0"
@@ -311,6 +312,7 @@ let builtin_ocaml_of_distro (d:t) : string option =
   |`Alpine `V3_11 -> Some "4.08.1"
   |`Alpine `V3_12 -> Some "4.08.1"
   |`Alpine `V3_13 -> Some "4.08.1"
+  |`Alpine `V3_14 -> Some "4.12.0"
   |`Archlinux `Latest -> Some "4.11.1"
   |`Fedora `V21 -> Some "4.01.0"
   |`Fedora `V22 -> Some "4.02.0"
@@ -404,6 +406,7 @@ let tag_of_distro (d:t) = match d with
   |`Ubuntu `V20_04 -> "ubuntu-20.04"
   |`Ubuntu `V20_10 -> "ubuntu-20.10"
   |`Ubuntu `V21_04 -> "ubuntu-21.04"
+  |`Ubuntu `V21_10 -> "ubuntu-21.10"
   |`Ubuntu `Latest -> "ubuntu"
   |`Ubuntu `LTS -> "ubuntu-lts"
   |`Debian `Stable -> "debian-stable"
@@ -447,6 +450,7 @@ let tag_of_distro (d:t) = match d with
   |`Alpine `V3_11 -> "alpine-3.11"
   |`Alpine `V3_12 -> "alpine-3.12"
   |`Alpine `V3_13 -> "alpine-3.13"
+  |`Alpine `V3_14 -> "alpine-3.14"
   |`Alpine `Latest -> "alpine"
   |`Archlinux `Latest -> "archlinux"
   |`OpenSUSE `V42_1 -> "opensuse-42.1"
@@ -484,6 +488,7 @@ let distro_of_tag x : t option =
   |"ubuntu-20.04" -> Some (`Ubuntu `V20_04)
   |"ubuntu-20.10" -> Some (`Ubuntu `V20_10)
   |"ubuntu-21.04" -> Some (`Ubuntu `V21_04)
+  |"ubuntu-21.10" -> Some (`Ubuntu `V21_10)
   |"ubuntu" -> Some (`Ubuntu `Latest)
   |"ubuntu-lts" -> Some (`Ubuntu `LTS)
   |"debian-stable" -> Some (`Debian `Stable)
@@ -526,6 +531,7 @@ let distro_of_tag x : t option =
   |"alpine-3.11" -> Some (`Alpine `V3_11)
   |"alpine-3.12" -> Some (`Alpine `V3_12)
   |"alpine-3.13" -> Some (`Alpine `V3_13)
+  |"alpine-3.14" -> Some (`Alpine `V3_14)
   |"alpine" -> Some (`Alpine `Latest)
   |"archlinux" -> Some (`Archlinux `Latest)
   |"opensuse-42.1" -> Some (`OpenSUSE `V42_1)
@@ -562,6 +568,7 @@ let rec human_readable_string_of_distro (d:t) =
   |`Ubuntu `V20_04 -> "Ubuntu 20.04"
   |`Ubuntu `V20_10 -> "Ubuntu 20.10"
   |`Ubuntu `V21_04 -> "Ubuntu 21.04"
+  |`Ubuntu `V21_10 -> "Ubuntu 21.10"
   |`Debian `Stable -> "Debian Stable"
   |`Debian `Unstable -> "Debian Unstable"
   |`Debian `Testing -> "Debian Testing"
@@ -600,6 +607,7 @@ let rec human_readable_string_of_distro (d:t) =
   |`Alpine `V3_11 -> "Alpine 3.11"
   |`Alpine `V3_12 -> "Alpine 3.12"
   |`Alpine `V3_13 -> "Alpine 3.13"
+  |`Alpine `V3_14 -> "Alpine 3.14"
   |`Archlinux `Latest -> "Archlinux"
   |`OpenSUSE `V42_1 -> "OpenSUSE 42.1"
   |`OpenSUSE `V42_2 -> "OpenSUSE 42.2"
@@ -673,6 +681,7 @@ let base_distro_tag ?win10_revision ?(arch=`X86_64) d =
         | `V3_11 -> "3.11"
         | `V3_12 -> "3.12"
         | `V3_13 -> "3.13"
+        | `V3_14 -> "3.14"
         | `Latest -> assert false
       in
       match arch with
@@ -716,6 +725,7 @@ let base_distro_tag ?win10_revision ?(arch=`X86_64) d =
         | `V20_04 -> "focal"
         | `V20_10 -> "groovy"
         | `V21_04 -> "hirsute"
+        | `V21_10 -> "impish"
         | `Latest | `LTS -> assert false
       in
       "ubuntu", tag

--- a/src-opam/dockerfile_distro.mli
+++ b/src-opam/dockerfile_distro.mli
@@ -47,14 +47,14 @@ type win10_revision = win10_release * win10_lcu option [@@deriving sexp]
 (** A Windows 10 version optionally with an LCU. *)
 
 type t = [
-  | `Alpine of [ `V3_3 | `V3_4 | `V3_5 | `V3_6 | `V3_7 | `V3_8 | `V3_9 | `V3_10 | `V3_11 | `V3_12 | `V3_13 | `Latest ]
+  | `Alpine of [ `V3_3 | `V3_4 | `V3_5 | `V3_6 | `V3_7 | `V3_8 | `V3_9 | `V3_10 | `V3_11 | `V3_12 | `V3_13 | `V3_14 | `Latest ]
   | `Archlinux of [ `Latest ]
   | `CentOS of [ `V6 | `V7 | `V8 | `Latest ]
   | `Debian of [ `V11 | `V10 | `V9 | `V8 | `V7 | `Stable | `Testing | `Unstable ]
   | `Fedora of [ `V21 | `V22 | `V23 | `V24 | `V25 | `V26 | `V27 | `V28 | `V29 | `V30 | `V31 | `V32 | `V33 | `V34 | `Latest ]
   | `OracleLinux of [ `V7 | `V8 | `Latest ]
   | `OpenSUSE of [ `V42_1 | `V42_2 | `V42_3 | `V15_0 | `V15_1 | `V15_2 | `V15_3 | `Latest ]
-  | `Ubuntu of [ `V12_04 | `V14_04 | `V15_04 | `V15_10 | `V16_04 | `V16_10 | `V17_04 | `V17_10 | `V18_04 | `V18_10 | `V19_04 | `V19_10 | `V20_04 | `V20_10 | `V21_04 | `LTS | `Latest ]
+  | `Ubuntu of [ `V12_04 | `V14_04 | `V15_04 | `V15_10 | `V16_04 | `V16_10 | `V17_04 | `V17_10 | `V18_04 | `V18_10 | `V19_04 | `V19_10 | `V20_04 | `V20_10 | `V21_04 | `V21_10 | `LTS | `Latest ]
   | `Cygwin of win10_release
   | `Windows of [`Mingw | `Msvc] * win10_release
 ] [@@deriving sexp]


### PR DESCRIPTION
- Add Alpine 3.14 and Ubuntu 21.10
- Move Fedora 33 and OpenSUSE 15.2 to deprecated and Alpine 3.13 to Tier 2.
- Latest Fedora is now Fedora 34