### PR TITLE
Partially revert #66

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 unreleased
 ----------
 
+- Asssume Windows x64 is an active distro even when it doesn't have the latest
+  release (@dra27 #66; #68)
 - Ensure stray double-quotes don't end up in PATH on Windows images (@dra27 #62)
 - Stop pinning binutils to 2.35 in Windows builds as that no longer works with
   GCC 11. (@dra27 #61)

--- a/src-opam/dockerfile_distro.ml
+++ b/src-opam/dockerfile_distro.ml
@@ -250,7 +250,6 @@ let distro_arches ov (d:t) =
   | `Fedora (`V33|`V34), ov when OV.(compare Releases.v4_08_0 ov) = -1  -> [ `X86_64; `Aarch64 ]
   (* 2021-04-19: should be 4.03 but there's a linking failure until 4.06. *)
   | `Windows (`Msvc, _), ov when OV.(compare Releases.v4_06_0 ov) = 1 -> []
-  | `Windows (_, _), ov when OV.(compare ov Releases.v4_13_0) >= 0 -> []
   | _ -> [ `X86_64 ]
 
 


### PR DESCRIPTION
opam-repository-mingw now has 4.13.0 and 4.12.1, so there's no need to hold the Windows images back. I've left the distro mechanism change in, though (as that may come in handy again....)