### PR TITLE
Add Ubuntu 21.10 to Tier2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ unreleased
 - Switch all GitHub access from git:// to https:// in advance of insecure protocol
   sunset (@kit-ty-kate #73)
 - Fix dependencies of dockerfile-cmd: result now correctly used (@dra27 #72)
+- Move Ubuntu 21.04 to deprecated (@dra27 #71)
 - Add Ubuntu 22.04 (@dra27 #71)
 - Add Alpine 3.14 and Ubuntu 21.10 (@avsm)
 - Move Fedora 33 and OpenSUSE 15.2 to deprecated and Alpine 3.13 to Tier 2. (@avsm)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ unreleased
 - Switch all GitHub access from git:// to https:// in advance of insecure protocol
   sunset (@kit-ty-kate #73)
 - Fix dependencies of dockerfile-cmd: result now correctly used (@dra27 #72)
+- Add Fedora 35 and make the latest (@dra27 #71)
 - Move Ubuntu 21.04 to deprecated (@dra27 #71)
 - Add Ubuntu 22.04 (@dra27 #71)
 - Add Alpine 3.14 and Ubuntu 21.10 (@avsm)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ unreleased
 - Switch all GitHub access from git:// to https:// in advance of insecure protocol
   sunset (@kit-ty-kate #73)
 - Fix dependencies of dockerfile-cmd: result now correctly used (@dra27 #72)
+- Add Ubuntu 22.04 (@dra27 #71)
 - Add Alpine 3.14 and Ubuntu 21.10 (@avsm)
 - Move Fedora 33 and OpenSUSE 15.2 to deprecated and Alpine 3.13 to Tier 2. (@avsm)
 - Latest Fedora is now Fedora 34 (@avsm)

--- a/src-opam/dockerfile_distro.ml
+++ b/src-opam/dockerfile_distro.ml
@@ -167,7 +167,7 @@ let distros : t list = [
   `OracleLinux `V7; `OracleLinux `V8; `OracleLinux `Latest;
   `OpenSUSE `V42_1; `OpenSUSE `V42_2; `OpenSUSE `V42_3; `OpenSUSE `V15_0; `OpenSUSE `V15_1; `OpenSUSE `V15_2; `OpenSUSE `V15_3; `OpenSUSE `Latest;
   `Ubuntu `V12_04; `Ubuntu `V14_04; `Ubuntu `V15_04; `Ubuntu `V15_10;
-  `Ubuntu `V16_04; `Ubuntu `V16_10; `Ubuntu `V17_04; `Ubuntu `V17_10; `Ubuntu `V18_04; `Ubuntu `V18_10; `Ubuntu `V19_04; `Ubuntu `V19_10; `Ubuntu `V20_04; `Ubuntu `V20_10; `Ubuntu `V21_04; (*`Ubuntu `V21_10;*)
+  `Ubuntu `V16_04; `Ubuntu `V16_10; `Ubuntu `V17_04; `Ubuntu `V17_10; `Ubuntu `V18_04; `Ubuntu `V18_10; `Ubuntu `V19_04; `Ubuntu `V19_10; `Ubuntu `V20_04; `Ubuntu `V20_10; `Ubuntu `V21_04; `Ubuntu `V21_10;
   `Ubuntu `Latest; `Ubuntu `LTS;
 ]
 let distros =
@@ -243,7 +243,7 @@ let distro_status (d:t) : status = match d with
   | `OpenSUSE `V15_3 -> `Active `Tier2
   | `OpenSUSE `Latest -> `Alias (`OpenSUSE `V15_3)
   | `Ubuntu (`V18_04) -> `Active `Tier3
-  | `Ubuntu (`V20_04 | `V21_04 |`V21_10) -> `Active `Tier2
+  | `Ubuntu (`V20_04 | `V21_04 | `V21_10) -> `Active `Tier2
   | `Ubuntu ( `V12_04 | `V14_04 | `V15_04 | `V15_10 | `V16_04 | `V16_10 | `V17_04 | `V17_10 | `V18_10 | `V19_04 | `V19_10 | `V20_10) -> `Deprecated
   | `Ubuntu `LTS -> `Alias (`Ubuntu `V20_04)
   | `Ubuntu `Latest -> `Alias (`Ubuntu `V21_04)
@@ -286,7 +286,7 @@ let distro_arches ov (d:t) =
   | `Debian `V10, ov when OV.(compare Releases.v4_05_0 ov) = -1 -> [ `I386; `X86_64; `Aarch64; `Ppc64le; `Aarch32; `S390x ]
   | `Debian `V9, ov when OV.(compare Releases.v4_05_0 ov) = -1 -> [ `I386; `X86_64; `Aarch64; `Aarch32 ]
   | `Alpine (`V3_6 | `V3_7 | `V3_8 | `V3_9 | `V3_10 | `V3_11 | `V3_12 | `V3_13 | `V3_14 | `V3_15), ov when OV.(compare Releases.v4_05_0 ov) = -1 -> [ `X86_64; `Aarch64 ]
-  | `Ubuntu (`V18_04|`V20_04|`V20_10|`V21_04 |`V21_10), ov when OV.(compare Releases.v4_05_0 ov) = -1  -> [ `X86_64; `Aarch64; `Ppc64le ]
+  | `Ubuntu (`V18_04|`V20_04|`V20_10|`V21_04|`V21_10), ov when OV.(compare Releases.v4_05_0 ov) = -1  -> [ `X86_64; `Aarch64; `Ppc64le ]
   | `Fedora (`V33|`V34), ov when OV.(compare Releases.v4_08_0 ov) = -1  -> [ `X86_64; `Aarch64 ]
   (* 2021-04-19: should be 4.03 but there's a linking failure until 4.06. *)
   | `Windows (`Msvc, _), ov when OV.(compare Releases.v4_06_0 ov) = 1 -> []

--- a/src-opam/dockerfile_distro.ml
+++ b/src-opam/dockerfile_distro.ml
@@ -120,7 +120,7 @@ type t = [
   | `Fedora of [ `V21 | `V22 | `V23 | `V24 | `V25 | `V26 | `V27 | `V28 | `V29 | `V30 | `V31 | `V32 | `V33 | `V34 | `Latest ]
   | `OracleLinux of [ `V7 | `V8 | `Latest ]
   | `OpenSUSE of [ `V42_1 | `V42_2 | `V42_3 | `V15_0 | `V15_1 | `V15_2 | `V15_3 | `Latest ]
-  | `Ubuntu of [ `V12_04 | `V14_04 | `V15_04 | `V15_10 | `V16_04 | `V16_10 | `V17_04 | `V17_10 | `V18_04 | `V18_10 | `V19_04 | `V19_10 | `V20_04 | `V20_10 | `V21_04 | `V21_10 | `LTS | `Latest ]
+  | `Ubuntu of [ `V12_04 | `V14_04 | `V15_04 | `V15_10 | `V16_04 | `V16_10 | `V17_04 | `V17_10 | `V18_04 | `V18_10 | `V19_04 | `V19_10 | `V20_04 | `V20_10 | `V21_04 | `V21_10 | `V22_04 | `LTS | `Latest ]
   | `Cygwin of win10_release
   | `Windows of [`Mingw | `Msvc] * win10_release
 ] [@@deriving sexp]
@@ -167,7 +167,7 @@ let distros : t list = [
   `OracleLinux `V7; `OracleLinux `V8; `OracleLinux `Latest;
   `OpenSUSE `V42_1; `OpenSUSE `V42_2; `OpenSUSE `V42_3; `OpenSUSE `V15_0; `OpenSUSE `V15_1; `OpenSUSE `V15_2; `OpenSUSE `V15_3; `OpenSUSE `Latest;
   `Ubuntu `V12_04; `Ubuntu `V14_04; `Ubuntu `V15_04; `Ubuntu `V15_10;
-  `Ubuntu `V16_04; `Ubuntu `V16_10; `Ubuntu `V17_04; `Ubuntu `V17_10; `Ubuntu `V18_04; `Ubuntu `V18_10; `Ubuntu `V19_04; `Ubuntu `V19_10; `Ubuntu `V20_04; `Ubuntu `V20_10; `Ubuntu `V21_04; `Ubuntu `V21_10;
+  `Ubuntu `V16_04; `Ubuntu `V16_10; `Ubuntu `V17_04; `Ubuntu `V17_10; `Ubuntu `V18_04; `Ubuntu `V18_10; `Ubuntu `V19_04; `Ubuntu `V19_10; `Ubuntu `V20_04; `Ubuntu `V20_10; `Ubuntu `V21_04; `Ubuntu `V21_10; `Ubuntu `V22_04;
   `Ubuntu `Latest; `Ubuntu `LTS;
 ]
 let distros =
@@ -243,7 +243,7 @@ let distro_status (d:t) : status = match d with
   | `OpenSUSE `V15_3 -> `Active `Tier2
   | `OpenSUSE `Latest -> `Alias (`OpenSUSE `V15_3)
   | `Ubuntu (`V18_04) -> `Active `Tier3
-  | `Ubuntu (`V20_04 | `V21_04 | `V21_10) -> `Active `Tier2
+  | `Ubuntu (`V20_04 | `V21_04 | `V21_10 | `V22_04) -> `Active `Tier2
   | `Ubuntu ( `V12_04 | `V14_04 | `V15_04 | `V15_10 | `V16_04 | `V16_10 | `V17_04 | `V17_10 | `V18_10 | `V19_04 | `V19_10 | `V20_10) -> `Deprecated
   | `Ubuntu `LTS -> `Alias (`Ubuntu `V20_04)
   | `Ubuntu `Latest -> `Alias (`Ubuntu `V21_04)
@@ -286,7 +286,7 @@ let distro_arches ov (d:t) =
   | `Debian `V10, ov when OV.(compare Releases.v4_05_0 ov) = -1 -> [ `I386; `X86_64; `Aarch64; `Ppc64le; `Aarch32; `S390x ]
   | `Debian `V9, ov when OV.(compare Releases.v4_05_0 ov) = -1 -> [ `I386; `X86_64; `Aarch64; `Aarch32 ]
   | `Alpine (`V3_6 | `V3_7 | `V3_8 | `V3_9 | `V3_10 | `V3_11 | `V3_12 | `V3_13 | `V3_14 | `V3_15), ov when OV.(compare Releases.v4_05_0 ov) = -1 -> [ `X86_64; `Aarch64 ]
-  | `Ubuntu (`V18_04|`V20_04|`V20_10|`V21_04|`V21_10), ov when OV.(compare Releases.v4_05_0 ov) = -1  -> [ `X86_64; `Aarch64; `Ppc64le ]
+  | `Ubuntu (`V18_04|`V20_04|`V20_10|`V21_04|`V21_10|`V22_04), ov when OV.(compare Releases.v4_05_0 ov) = -1  -> [ `X86_64; `Aarch64; `Ppc64le ]
   | `Fedora (`V33|`V34), ov when OV.(compare Releases.v4_08_0 ov) = -1  -> [ `X86_64; `Aarch64 ]
   (* 2021-04-19: should be 4.03 but there's a linking failure until 4.06. *)
   | `Windows (`Msvc, _), ov when OV.(compare Releases.v4_06_0 ov) = 1 -> []
@@ -341,6 +341,7 @@ let builtin_ocaml_of_distro (d:t) : string option =
   |`Ubuntu `V20_10 -> Some "4.08.1"
   |`Ubuntu `V21_04 -> Some "4.11.1"
   |`Ubuntu `V21_10 -> Some "4.11.1"
+  |`Ubuntu `V22_04 -> failwith "4.11.1; not yet confirmed"
   |`Alpine `V3_3 -> Some "4.02.3"
   |`Alpine `V3_4 -> Some "4.02.3"
   |`Alpine `V3_5 -> Some "4.04.0"
@@ -450,6 +451,7 @@ let tag_of_distro (d:t) = match d with
   |`Ubuntu `V20_10 -> "ubuntu-20.10"
   |`Ubuntu `V21_04 -> "ubuntu-21.04"
   |`Ubuntu `V21_10 -> "ubuntu-21.10"
+  |`Ubuntu `V22_04 -> "ubuntu-22.04"
   |`Ubuntu `Latest -> "ubuntu"
   |`Ubuntu `LTS -> "ubuntu-lts"
   |`Debian `Stable -> "debian-stable"
@@ -533,6 +535,7 @@ let distro_of_tag x : t option =
   |"ubuntu-20.10" -> Some (`Ubuntu `V20_10)
   |"ubuntu-21.04" -> Some (`Ubuntu `V21_04)
   |"ubuntu-21.10" -> Some (`Ubuntu `V21_10)
+  |"ubuntu-22.04" -> Some (`Ubuntu `V22_04)
   |"ubuntu" -> Some (`Ubuntu `Latest)
   |"ubuntu-lts" -> Some (`Ubuntu `LTS)
   |"debian-stable" -> Some (`Debian `Stable)
@@ -614,6 +617,7 @@ let rec human_readable_string_of_distro (d:t) =
   |`Ubuntu `V20_10 -> "Ubuntu 20.10"
   |`Ubuntu `V21_04 -> "Ubuntu 21.04"
   |`Ubuntu `V21_10 -> "Ubuntu 21.10"
+  |`Ubuntu `V22_04 -> "Ubuntu 22.04"
   |`Debian `Stable -> "Debian Stable"
   |`Debian `Unstable -> "Debian Unstable"
   |`Debian `Testing -> "Debian Testing"
@@ -781,6 +785,7 @@ let base_distro_tag ?win10_revision ?(arch=`X86_64) d =
         | `V20_10 -> "groovy"
         | `V21_04 -> "hirsute"
         | `V21_10 -> "impish"
+        | `V22_04 -> "jammy"
         | `Latest | `LTS -> assert false
       in
       "ubuntu", tag

--- a/src-opam/dockerfile_distro.ml
+++ b/src-opam/dockerfile_distro.ml
@@ -243,10 +243,10 @@ let distro_status (d:t) : status = match d with
   | `OpenSUSE `V15_3 -> `Active `Tier2
   | `OpenSUSE `Latest -> `Alias (`OpenSUSE `V15_3)
   | `Ubuntu (`V18_04) -> `Active `Tier3
-  | `Ubuntu (`V20_04 | `V21_04 | `V21_10 | `V22_04) -> `Active `Tier2
-  | `Ubuntu ( `V12_04 | `V14_04 | `V15_04 | `V15_10 | `V16_04 | `V16_10 | `V17_04 | `V17_10 | `V18_10 | `V19_04 | `V19_10 | `V20_10) -> `Deprecated
+  | `Ubuntu (`V20_04 | `V21_10 | `V22_04) -> `Active `Tier2
+  | `Ubuntu (`V12_04 | `V14_04 | `V15_04 | `V15_10 | `V16_04 | `V16_10 | `V17_04 | `V17_10 | `V18_10 | `V19_04 | `V19_10 | `V20_10 | `V21_04) -> `Deprecated
   | `Ubuntu `LTS -> `Alias (`Ubuntu `V20_04)
-  | `Ubuntu `Latest -> `Alias (`Ubuntu `V21_04)
+  | `Ubuntu `Latest -> `Alias (`Ubuntu `V21_10)
   | `Cygwin `Ltsc2019 -> `Alias (`Cygwin `V1809)
   | `Cygwin `Ltsc2016 -> `Alias (`Cygwin `V1607)
   | `Cygwin `Ltsc2015 -> `Alias (`Cygwin `V1507)

--- a/src-opam/dockerfile_distro.ml
+++ b/src-opam/dockerfile_distro.ml
@@ -286,7 +286,9 @@ let distro_arches ov (d:t) =
   | `Debian `V10, ov when OV.(compare Releases.v4_05_0 ov) = -1 -> [ `I386; `X86_64; `Aarch64; `Ppc64le; `Aarch32; `S390x ]
   | `Debian `V9, ov when OV.(compare Releases.v4_05_0 ov) = -1 -> [ `I386; `X86_64; `Aarch64; `Aarch32 ]
   | `Alpine (`V3_6 | `V3_7 | `V3_8 | `V3_9 | `V3_10 | `V3_11 | `V3_12 | `V3_13 | `V3_14 | `V3_15), ov when OV.(compare Releases.v4_05_0 ov) = -1 -> [ `X86_64; `Aarch64 ]
-  | `Ubuntu (`V18_04|`V20_04|`V20_10|`V21_04|`V21_10|`V22_04), ov when OV.(compare Releases.v4_05_0 ov) = -1  -> [ `X86_64; `Aarch64; `Ppc64le ]
+  (* 2022-01-24: ppc64le seems to be broken on Jammy at the moment? *)
+  | `Ubuntu `V22_04, ov when OV.(compare Releases.v4_05_0 ov) = -1  -> [ `X86_64; `Aarch64]
+  | `Ubuntu (`V18_04|`V20_04|`V20_10|`V21_04|`V21_10), ov when OV.(compare Releases.v4_05_0 ov) = -1  -> [ `X86_64; `Aarch64; `Ppc64le ]
   | `Fedora (`V33|`V34|`V35), ov when OV.(compare Releases.v4_08_0 ov) = -1  -> [ `X86_64; `Aarch64 ]
   (* 2021-04-19: should be 4.03 but there's a linking failure until 4.06. *)
   | `Windows (`Msvc, _), ov when OV.(compare Releases.v4_06_0 ov) = 1 -> []

--- a/src-opam/dockerfile_distro.ml
+++ b/src-opam/dockerfile_distro.ml
@@ -117,7 +117,7 @@ type t = [
   | `Archlinux of [ `Latest ]
   | `CentOS of [ `V6 | `V7 | `V8 | `Latest ]
   | `Debian of [ `V11 | `V10 | `V9 | `V8 | `V7 | `Stable | `Testing | `Unstable ]
-  | `Fedora of [ `V21 | `V22 | `V23 | `V24 | `V25 | `V26 | `V27 | `V28 | `V29 | `V30 | `V31 | `V32 | `V33 | `V34 | `Latest ]
+  | `Fedora of [ `V21 | `V22 | `V23 | `V24 | `V25 | `V26 | `V27 | `V28 | `V29 | `V30 | `V31 | `V32 | `V33 | `V34 | `V35 | `Latest ]
   | `OracleLinux of [ `V7 | `V8 | `Latest ]
   | `OpenSUSE of [ `V42_1 | `V42_2 | `V42_3 | `V15_0 | `V15_1 | `V15_2 | `V15_3 | `Latest ]
   | `Ubuntu of [ `V12_04 | `V14_04 | `V15_04 | `V15_10 | `V16_04 | `V16_10 | `V17_04 | `V17_10 | `V18_04 | `V18_10 | `V19_04 | `V19_10 | `V20_04 | `V20_10 | `V21_04 | `V21_10 | `V22_04 | `LTS | `Latest ]
@@ -163,7 +163,7 @@ let distros : t list = [
   `CentOS `V6; `CentOS `V7; `CentOS `V8; `CentOS `Latest;
   `Debian `V11; `Debian `V10; `Debian `V9; `Debian `V8; `Debian `V7;
   `Debian `Stable; `Debian `Testing; `Debian `Unstable;
-  `Fedora `V23; `Fedora `V24; `Fedora `V25; `Fedora `V26; `Fedora `V27; `Fedora `V28; `Fedora `V29; `Fedora `V30; `Fedora `V31; `Fedora `V32; `Fedora `V33; `Fedora `V34; `Fedora `Latest;
+  `Fedora `V23; `Fedora `V24; `Fedora `V25; `Fedora `V26; `Fedora `V27; `Fedora `V28; `Fedora `V29; `Fedora `V30; `Fedora `V31; `Fedora `V32; `Fedora `V33; `Fedora `V34; `Fedora `V35; `Fedora `Latest;
   `OracleLinux `V7; `OracleLinux `V8; `OracleLinux `Latest;
   `OpenSUSE `V42_1; `OpenSUSE `V42_2; `OpenSUSE `V42_3; `OpenSUSE `V15_0; `OpenSUSE `V15_1; `OpenSUSE `V15_2; `OpenSUSE `V15_3; `OpenSUSE `Latest;
   `Ubuntu `V12_04; `Ubuntu `V14_04; `Ubuntu `V15_04; `Ubuntu `V15_10;
@@ -235,8 +235,8 @@ let distro_status (d:t) : status = match d with
   | `Debian `Testing -> `Active `Tier3
   | `Debian `Unstable -> `Active `Tier3
   | `Fedora ( `V21 | `V22 | `V23 | `V24 | `V25 | `V26 | `V27 | `V28 | `V29 | `V30 | `V31 | `V32 | `V33) -> `Deprecated
-  | `Fedora `V34 -> `Active `Tier2
-  | `Fedora `Latest -> `Alias (`Fedora `V34)
+  | `Fedora (`V34 | `V35) -> `Active `Tier2
+  | `Fedora `Latest -> `Alias (`Fedora `V35)
   | `OracleLinux (`V7|`V8) -> `Active `Tier3
   | `OracleLinux `Latest -> `Alias (`OracleLinux `V8)
   | `OpenSUSE (`V42_1 | `V42_2 | `V42_3 | `V15_0 | `V15_1 | `V15_2) -> `Deprecated
@@ -287,7 +287,7 @@ let distro_arches ov (d:t) =
   | `Debian `V9, ov when OV.(compare Releases.v4_05_0 ov) = -1 -> [ `I386; `X86_64; `Aarch64; `Aarch32 ]
   | `Alpine (`V3_6 | `V3_7 | `V3_8 | `V3_9 | `V3_10 | `V3_11 | `V3_12 | `V3_13 | `V3_14 | `V3_15), ov when OV.(compare Releases.v4_05_0 ov) = -1 -> [ `X86_64; `Aarch64 ]
   | `Ubuntu (`V18_04|`V20_04|`V20_10|`V21_04|`V21_10|`V22_04), ov when OV.(compare Releases.v4_05_0 ov) = -1  -> [ `X86_64; `Aarch64; `Ppc64le ]
-  | `Fedora (`V33|`V34), ov when OV.(compare Releases.v4_08_0 ov) = -1  -> [ `X86_64; `Aarch64 ]
+  | `Fedora (`V33|`V34|`V35), ov when OV.(compare Releases.v4_08_0 ov) = -1  -> [ `X86_64; `Aarch64 ]
   (* 2021-04-19: should be 4.03 but there's a linking failure until 4.06. *)
   | `Windows (`Msvc, _), ov when OV.(compare Releases.v4_06_0 ov) = 1 -> []
   | _ -> [ `X86_64 ]
@@ -370,6 +370,7 @@ let builtin_ocaml_of_distro (d:t) : string option =
   |`Fedora `V32 -> Some "4.10.0"
   |`Fedora `V33 -> Some "4.11.1"
   |`Fedora `V34 -> Some "4.11.1"
+  |`Fedora `V35 -> Some "4.12.0"
   |`CentOS `V6 -> Some "3.11.2"
   |`CentOS `V7 -> Some "4.01.0"
   |`CentOS `V8 -> Some "4.07.0"
@@ -481,6 +482,7 @@ let tag_of_distro (d:t) = match d with
   |`Fedora `V32 -> "fedora-32"
   |`Fedora `V33 -> "fedora-33"
   |`Fedora `V34 -> "fedora-34"
+  |`Fedora `V35 -> "fedora-35"
   |`OracleLinux `V7 -> "oraclelinux-7"
   |`OracleLinux `V8 -> "oraclelinux-8"
   |`OracleLinux `Latest -> "oraclelinux"
@@ -563,6 +565,7 @@ let distro_of_tag x : t option =
   |"fedora-32" -> Some (`Fedora `V32)
   |"fedora-33" -> Some (`Fedora `V33)
   |"fedora-34" -> Some (`Fedora `V34)
+  |"fedora-35" -> Some (`Fedora `V35)
   |"fedora" -> Some (`Fedora `Latest)
   |"oraclelinux-7" -> Some (`OracleLinux `V7)
   |"oraclelinux-8" -> Some (`OracleLinux `V8)
@@ -643,6 +646,7 @@ let rec human_readable_string_of_distro (d:t) =
   |`Fedora `V32 -> "Fedora 32"
   |`Fedora `V33 -> "Fedora 33"
   |`Fedora `V34 -> "Fedora 34"
+  |`Fedora `V35 -> "Fedora 35"
   |`OracleLinux `V7 -> "OracleLinux 7"
   |`OracleLinux `V8 -> "OracleLinux 8"
   |`Alpine `V3_3 -> "Alpine 3.3"
@@ -809,6 +813,7 @@ let base_distro_tag ?win10_revision ?(arch=`X86_64) d =
         | `V32 -> "32"
         | `V33 -> "33"
         | `V34 -> "34"
+        | `V35 -> "35"
         | `Latest -> assert false
       in
       "fedora", tag

--- a/src-opam/dockerfile_distro.mli
+++ b/src-opam/dockerfile_distro.mli
@@ -57,7 +57,7 @@ type t = [
   | `Archlinux of [ `Latest ]
   | `CentOS of [ `V6 | `V7 | `V8 | `Latest ]
   | `Debian of [ `V11 | `V10 | `V9 | `V8 | `V7 | `Stable | `Testing | `Unstable ]
-  | `Fedora of [ `V21 | `V22 | `V23 | `V24 | `V25 | `V26 | `V27 | `V28 | `V29 | `V30 | `V31 | `V32 | `V33 | `V34 | `Latest ]
+  | `Fedora of [ `V21 | `V22 | `V23 | `V24 | `V25 | `V26 | `V27 | `V28 | `V29 | `V30 | `V31 | `V32 | `V33 | `V34 | `V35 | `Latest ]
   | `OracleLinux of [ `V7 | `V8 | `Latest ]
   | `OpenSUSE of [ `V42_1 | `V42_2 | `V42_3 | `V15_0 | `V15_1 | `V15_2 | `V15_3 | `Latest ]
   | `Ubuntu of [ `V12_04 | `V14_04 | `V15_04 | `V15_10 | `V16_04 | `V16_10 | `V17_04 | `V17_10 | `V18_04 | `V18_10 | `V19_04 | `V19_10 | `V20_04 | `V20_10 | `V21_04 | `V21_10 | `V22_04 | `LTS | `Latest ]

--- a/src-opam/dockerfile_distro.mli
+++ b/src-opam/dockerfile_distro.mli
@@ -60,7 +60,7 @@ type t = [
   | `Fedora of [ `V21 | `V22 | `V23 | `V24 | `V25 | `V26 | `V27 | `V28 | `V29 | `V30 | `V31 | `V32 | `V33 | `V34 | `Latest ]
   | `OracleLinux of [ `V7 | `V8 | `Latest ]
   | `OpenSUSE of [ `V42_1 | `V42_2 | `V42_3 | `V15_0 | `V15_1 | `V15_2 | `V15_3 | `Latest ]
-  | `Ubuntu of [ `V12_04 | `V14_04 | `V15_04 | `V15_10 | `V16_04 | `V16_10 | `V17_04 | `V17_10 | `V18_04 | `V18_10 | `V19_04 | `V19_10 | `V20_04 | `V20_10 | `V21_04 | `V21_10 | `LTS | `Latest ]
+  | `Ubuntu of [ `V12_04 | `V14_04 | `V15_04 | `V15_10 | `V16_04 | `V16_10 | `V17_04 | `V17_10 | `V18_04 | `V18_10 | `V19_04 | `V19_10 | `V20_04 | `V20_10 | `V21_04 | `V21_10 | `V22_04 | `LTS | `Latest ]
   | `Cygwin of win10_release
   | `Windows of [`Mingw | `Msvc] * win10_release
 ] [@@deriving sexp]


### PR DESCRIPTION
- Enable Ubuntu Impish, now it's released (and hopefully working)
- Add Ubuntu 22.04 (Jammy) 
- Add October 2021 Windows LCU