### PR TITLE
Add opam master (opam-dev + opam-2.2) to the base images

### DIFF
--- a/src-opam/dockerfile_opam.ml
+++ b/src-opam/dockerfile_opam.ml
@@ -110,13 +110,14 @@ let header ?win10_revision ?arch ?maintainer ?img ?tag d =
   @@ shell
 
 (* Apk based Dockerfile *)
-let apk_opam2 ?(labels=[]) ?arch ~hash_opam_2_0 ~hash_opam_2_1 distro () =
+let apk_opam2 ?(labels=[]) ?arch ~hash_opam_2_0 ~hash_opam_2_1 ~hash_opam_master distro () =
   let img, tag = D.base_distro_tag ?arch distro in
   header ?arch distro @@ label (("distro_style", "apk") :: labels)
   @@ Linux.Apk.install "build-base bzip2 git tar curl ca-certificates openssl"
   @@ Linux.Git.init ()
   @@ install_opam_from_source ~add_default_link:false ~branch:"2.0" ~hash:hash_opam_2_0 ()
   @@ install_opam_from_source ~add_default_link:false ~enable_0install_solver:true ~branch:"2.1" ~hash:hash_opam_2_1 ()
+  @@ install_opam_from_source ~add_default_link:false ~enable_0install_solver:true ~branch:"master" ~hash:hash_opam_master ()
   @@ run "strip /usr/local/bin/opam*"
   @@ from ~tag img
   @@ Linux.Apk.add_repository ~tag:"edge" "https://dl-cdn.alpinelinux.org/alpine/edge/main"
@@ -124,6 +125,7 @@ let apk_opam2 ?(labels=[]) ?arch ~hash_opam_2_0 ~hash_opam_2_1 distro () =
   @@ Linux.Apk.add_repository ~tag:"testing" "https://dl-cdn.alpinelinux.org/alpine/edge/testing"
   @@ copy ~from:"0" ~src:["/usr/local/bin/opam-2.0"] ~dst:"/usr/bin/opam-2.0" ()
   @@ copy ~from:"0" ~src:["/usr/local/bin/opam-2.1"] ~dst:"/usr/bin/opam-2.1" ()
+  @@ copy ~from:"0" ~src:["/usr/local/bin/opam-master"] ~dst:"/usr/bin/opam-dev" ()
   @@ run "ln /usr/bin/opam-2.0 /usr/bin/opam"
   @@ Linux.Apk.dev_packages ()
   @@ Linux.Apk.add_user ~uid:1000 ~gid:1000 ~sudo:true "opam"
@@ -131,7 +133,7 @@ let apk_opam2 ?(labels=[]) ?arch ~hash_opam_2_0 ~hash_opam_2_1 distro () =
 
 
 (* Debian based Dockerfile *)
-let apt_opam2 ?(labels=[]) ?arch distro ~hash_opam_2_0 ~hash_opam_2_1 () =
+let apt_opam2 ?(labels=[]) ?arch distro ~hash_opam_2_0 ~hash_opam_2_1 ~hash_opam_master () =
   let img, tag = D.base_distro_tag ?arch distro in
   header ?arch distro @@ label (("distro_style", "apt") :: labels)
   @@ Linux.Apt.install "build-essential curl git libcap-dev sudo"
@@ -139,10 +141,12 @@ let apt_opam2 ?(labels=[]) ?arch distro ~hash_opam_2_0 ~hash_opam_2_1 () =
   @@ install_bubblewrap_from_source ()
   @@ install_opam_from_source ~add_default_link:false ~branch:"2.0" ~hash:hash_opam_2_0 ()
   @@ install_opam_from_source ~add_default_link:false ~enable_0install_solver:true ~branch:"2.1" ~hash:hash_opam_2_1 ()
+  @@ install_opam_from_source ~add_default_link:false ~enable_0install_solver:true ~branch:"master" ~hash:hash_opam_master ()
   @@ from ~tag img
   @@ copy ~from:"0" ~src:["/usr/local/bin/bwrap"] ~dst:"/usr/bin/bwrap" ()
   @@ copy ~from:"0" ~src:["/usr/local/bin/opam-2.0"] ~dst:"/usr/bin/opam-2.0" ()
   @@ copy ~from:"0" ~src:["/usr/local/bin/opam-2.1"] ~dst:"/usr/bin/opam-2.1" ()
+  @@ copy ~from:"0" ~src:["/usr/local/bin/opam-master"] ~dst:"/usr/bin/opam-dev" ()
   @@ run "ln /usr/bin/opam-2.0 /usr/bin/opam"
   @@ run "ln -fs /usr/share/zoneinfo/Europe/London /etc/localtime"
   @@ Linux.Apt.dev_packages ()
@@ -158,7 +162,7 @@ let apt_opam2 ?(labels=[]) ?arch distro ~hash_opam_2_0 ~hash_opam_2_1 () =
 
    [enable_powertools] enables the PowerTools repository on CentOS 8 and above.
    This is needed to get most of *-devel packages frequently used by opam packages. *)
-let yum_opam2 ?(labels= []) ?arch ~yum_workaround ~enable_powertools ~hash_opam_2_0 ~hash_opam_2_1 distro () =
+let yum_opam2 ?(labels= []) ?arch ~yum_workaround ~enable_powertools ~hash_opam_2_0 ~hash_opam_2_1 ~hash_opam_master distro () =
   let img, tag = D.base_distro_tag ?arch distro in
   let workaround =
     if yum_workaround then
@@ -175,6 +179,7 @@ let yum_opam2 ?(labels= []) ?arch ~yum_workaround ~enable_powertools ~hash_opam_
   @@ install_bubblewrap_from_source ()
   @@ install_opam_from_source ~prefix:"/usr" ~add_default_link:false ~branch:"2.0" ~hash:hash_opam_2_0 ()
   @@ install_opam_from_source ~prefix:"/usr" ~add_default_link:false ~enable_0install_solver:true ~branch:"2.1" ~hash:hash_opam_2_1 ()
+  @@ install_opam_from_source ~prefix:"/usr" ~add_default_link:false ~enable_0install_solver:true ~branch:"master" ~hash:hash_opam_master ()
   @@ from ~tag img
   @@ run "yum --version || dnf install -y yum"
   @@ workaround
@@ -184,6 +189,7 @@ let yum_opam2 ?(labels= []) ?arch ~yum_workaround ~enable_powertools ~hash_opam_
   @@ copy ~from:"0" ~src:["/usr/local/bin/bwrap"] ~dst:"/usr/bin/bwrap" ()
   @@ copy ~from:"0" ~src:["/usr/bin/opam-2.0"] ~dst:"/usr/bin/opam-2.0" ()
   @@ copy ~from:"0" ~src:["/usr/bin/opam-2.1"] ~dst:"/usr/bin/opam-2.1" ()
+  @@ copy ~from:"0" ~src:["/usr/bin/opam-master"] ~dst:"/usr/bin/opam-dev" ()
   @@ run "ln /usr/bin/opam-2.0 /usr/bin/opam"
   @@ run
        "sed -i.bak '/LC_TIME LC_ALL LANGUAGE/aDefaults    env_keep += \"OPAMYES OPAMJOBS OPAMVERBOSE\"' /etc/sudoers"
@@ -192,7 +198,7 @@ let yum_opam2 ?(labels= []) ?arch ~yum_workaround ~enable_powertools ~hash_opam_
 
 
 (* Zypper based Dockerfile *)
-let zypper_opam2 ?(labels=[]) ?arch ~hash_opam_2_0 ~hash_opam_2_1 distro () =
+let zypper_opam2 ?(labels=[]) ?arch ~hash_opam_2_0 ~hash_opam_2_1 ~hash_opam_master distro () =
   let img, tag = D.base_distro_tag ?arch distro in
   header ?arch distro @@ label (("distro_style", "zypper") :: labels)
   @@ Linux.Zypper.dev_packages ()
@@ -200,34 +206,38 @@ let zypper_opam2 ?(labels=[]) ?arch ~hash_opam_2_0 ~hash_opam_2_1 distro () =
   @@ install_bubblewrap_from_source ()
   @@ install_opam_from_source ~prefix:"/usr" ~add_default_link:false ~branch:"2.0" ~hash:hash_opam_2_0 ()
   @@ install_opam_from_source ~prefix:"/usr" ~add_default_link:false ~enable_0install_solver:true ~branch:"2.1" ~hash:hash_opam_2_1 ()
+  @@ install_opam_from_source ~prefix:"/usr" ~add_default_link:false ~enable_0install_solver:true ~branch:"master" ~hash:hash_opam_master ()
   @@ from ~tag img
   @@ Linux.Zypper.dev_packages ()
   @@ copy ~from:"0" ~src:["/usr/local/bin/bwrap"] ~dst:"/usr/bin/bwrap" ()
   @@ copy ~from:"0" ~src:["/usr/bin/opam-2.0"] ~dst:"/usr/bin/opam-2.0" ()
   @@ copy ~from:"0" ~src:["/usr/bin/opam-2.1"] ~dst:"/usr/bin/opam-2.1" ()
+  @@ copy ~from:"0" ~src:["/usr/bin/opam-master"] ~dst:"/usr/bin/opam-dev" ()
   @@ run "ln /usr/bin/opam-2.0 /usr/bin/opam"
   @@ Linux.Zypper.add_user ~uid:1000 ~sudo:true "opam"
   @@ install_bubblewrap_wrappers @@ Linux.Git.init ()
 
 (* Pacman based Dockerfile *)
-let pacman_opam2 ?(labels=[]) ?arch ~hash_opam_2_0 ~hash_opam_2_1 distro () =
+let pacman_opam2 ?(labels=[]) ?arch ~hash_opam_2_0 ~hash_opam_2_1 ~hash_opam_master distro () =
   let img, tag = D.base_distro_tag ?arch distro in
   header ?arch distro @@ label (("distro_style", "pacman") :: labels)
   @@ Linux.Pacman.dev_packages ()
   @@ Linux.Git.init ()
   @@ install_opam_from_source ~add_default_link:false ~branch:"2.0" ~hash:hash_opam_2_0 ()
   @@ install_opam_from_source ~add_default_link:false ~enable_0install_solver:true ~branch:"2.1" ~hash:hash_opam_2_1 ()
+  @@ install_opam_from_source ~add_default_link:false ~enable_0install_solver:true ~branch:"master" ~hash:hash_opam_master ()
   @@ run "strip /usr/local/bin/opam*"
   @@ from ~tag img
   @@ copy ~from:"0" ~src:["/usr/local/bin/opam-2.0"] ~dst:"/usr/bin/opam-2.0" ()
   @@ copy ~from:"0" ~src:["/usr/local/bin/opam-2.1"] ~dst:"/usr/bin/opam-2.1" ()
+  @@ copy ~from:"0" ~src:["/usr/local/bin/opam-master"] ~dst:"/usr/bin/opam-dev" ()
   @@ run "ln /usr/bin/opam-2.0 /usr/bin/opam"
   @@ Linux.Pacman.dev_packages ()
   @@ Linux.Pacman.add_user ~uid:1000 ~sudo:true "opam"
   @@ install_bubblewrap_wrappers @@ Linux.Git.init ()
 
 (* Cygwin based Dockerfile *)
-let cygwin_opam2 ?win10_revision ?(labels=[]) ?arch ~hash_opam_2_0 ~hash_opam_2_1 distro () =
+let cygwin_opam2 ?win10_revision ?(labels=[]) ?arch ~hash_opam_2_0 ~hash_opam_2_1 ~hash_opam_master distro () =
   let img, tag = D.base_distro_tag ?arch distro in
   let cyg = Windows.Cygwin.{ default with args = "--allow-test-packages" :: default.args } in
   header ?win10_revision ?arch distro @@ label (("distro_style", "cygwin") :: labels)
@@ -236,10 +246,12 @@ let cygwin_opam2 ?win10_revision ?(labels=[]) ?arch ~hash_opam_2_0 ~hash_opam_2_
   @@ Windows.Cygwin.Git.init ()
   @@ install_opam_from_source_cygwin ~add_default_link:false ~branch:"2.0" ~hash:hash_opam_2_0 ()
   @@ install_opam_from_source_cygwin ~add_default_link:false ~enable_0install_solver:true ~branch:"2.1" ~hash:hash_opam_2_1 ()
+  @@ install_opam_from_source_cygwin ~add_default_link:false ~enable_0install_solver:true ~branch:"master" ~hash:hash_opam_master ()
   @@ run "strip /usr/local/bin/opam*"
   @@ from ~tag img
   @@ copy ~from:"0" ~src:["/usr/local/bin/opam-2.0"] ~dst:"/usr/bin/opam-2.0" ()
   @@ copy ~from:"0" ~src:["/usr/local/bin/opam-2.1"] ~dst:"/usr/bin/opam-2.1" ()
+  @@ copy ~from:"0" ~src:["/usr/local/bin/opam-master"] ~dst:"/usr/bin/opam-dev" ()
   @@ run "ln /usr/bin/opam-2.0 /usr/bin/opam"
   @@ Windows.Cygwin.(setup ~cyg ~extra:(cygwin_packages ()) ())
   @@ Windows.Cygwin.Git.init ()
@@ -278,17 +290,17 @@ let windows_opam2 ?win10_revision ?winget ?(labels=[]) ?arch distro () =
   @@ Windows.Cygwin.Git.init ()
   @@ Windows.cleanup ()
 
-let gen_opam2_distro ?win10_revision ?winget ?(clone_opam_repo=true) ?arch ?labels ~hash_opam_2_0 ~hash_opam_2_1 d =
+let gen_opam2_distro ?win10_revision ?winget ?(clone_opam_repo=true) ?arch ?labels ~hash_opam_2_0 ~hash_opam_2_1 ~hash_opam_master d =
   let fn = match D.package_manager d with
-  | `Apk -> apk_opam2 ?labels ?arch ~hash_opam_2_0 ~hash_opam_2_1 d ()
-  | `Apt -> apt_opam2 ?labels ?arch ~hash_opam_2_0 ~hash_opam_2_1 d ()
+  | `Apk -> apk_opam2 ?labels ?arch ~hash_opam_2_0 ~hash_opam_2_1 ~hash_opam_master d ()
+  | `Apt -> apt_opam2 ?labels ?arch ~hash_opam_2_0 ~hash_opam_2_1 ~hash_opam_master d ()
   | `Yum ->
      let yum_workaround = match d with `CentOS `V7 -> true | _ -> false in
      let enable_powertools = match d with `CentOS (`V6 | `V7) -> false | `CentOS _ -> true | _ -> false in
-     yum_opam2 ?labels ?arch ~yum_workaround ~enable_powertools ~hash_opam_2_0 ~hash_opam_2_1 d ()
-  | `Zypper -> zypper_opam2 ?labels ?arch ~hash_opam_2_0 ~hash_opam_2_1 d ()
-  | `Pacman -> pacman_opam2 ?labels ?arch ~hash_opam_2_0 ~hash_opam_2_1 d ()
-  | `Cygwin -> cygwin_opam2 ?win10_revision ?labels ?arch ~hash_opam_2_0 ~hash_opam_2_1 d ()
+     yum_opam2 ?labels ?arch ~yum_workaround ~enable_powertools ~hash_opam_2_0 ~hash_opam_2_1 ~hash_opam_master d ()
+  | `Zypper -> zypper_opam2 ?labels ?arch ~hash_opam_2_0 ~hash_opam_2_1 ~hash_opam_master d ()
+  | `Pacman -> pacman_opam2 ?labels ?arch ~hash_opam_2_0 ~hash_opam_2_1 ~hash_opam_master d ()
+  | `Cygwin -> cygwin_opam2 ?win10_revision ?labels ?arch ~hash_opam_2_0 ~hash_opam_2_1 ~hash_opam_master d ()
   | `Windows -> windows_opam2 ?win10_revision ?winget ?labels ?arch d ()
   in
   let clone = if clone_opam_repo then

--- a/src-opam/dockerfile_opam.ml
+++ b/src-opam/dockerfile_opam.ml
@@ -125,6 +125,7 @@ let apk_opam2 ?(labels=[]) ?arch ~hash_opam_2_0 ~hash_opam_2_1 ~hash_opam_master
   @@ Linux.Apk.add_repository ~tag:"testing" "https://dl-cdn.alpinelinux.org/alpine/edge/testing"
   @@ copy ~from:"0" ~src:["/usr/local/bin/opam-2.0"] ~dst:"/usr/bin/opam-2.0" ()
   @@ copy ~from:"0" ~src:["/usr/local/bin/opam-2.1"] ~dst:"/usr/bin/opam-2.1" ()
+  @@ copy ~from:"0" ~src:["/usr/local/bin/opam-master"] ~dst:"/usr/bin/opam-2.2" () (* TODO: Change when opam 2.2 is branched *)
   @@ copy ~from:"0" ~src:["/usr/local/bin/opam-master"] ~dst:"/usr/bin/opam-dev" ()
   @@ run "ln /usr/bin/opam-2.0 /usr/bin/opam"
   @@ Linux.Apk.dev_packages ()
@@ -146,6 +147,7 @@ let apt_opam2 ?(labels=[]) ?arch distro ~hash_opam_2_0 ~hash_opam_2_1 ~hash_opam
   @@ copy ~from:"0" ~src:["/usr/local/bin/bwrap"] ~dst:"/usr/bin/bwrap" ()
   @@ copy ~from:"0" ~src:["/usr/local/bin/opam-2.0"] ~dst:"/usr/bin/opam-2.0" ()
   @@ copy ~from:"0" ~src:["/usr/local/bin/opam-2.1"] ~dst:"/usr/bin/opam-2.1" ()
+  @@ copy ~from:"0" ~src:["/usr/local/bin/opam-master"] ~dst:"/usr/bin/opam-2.2" () (* TODO: Change when opam 2.2 is branched *)
   @@ copy ~from:"0" ~src:["/usr/local/bin/opam-master"] ~dst:"/usr/bin/opam-dev" ()
   @@ run "ln /usr/bin/opam-2.0 /usr/bin/opam"
   @@ run "ln -fs /usr/share/zoneinfo/Europe/London /etc/localtime"
@@ -189,6 +191,7 @@ let yum_opam2 ?(labels= []) ?arch ~yum_workaround ~enable_powertools ~hash_opam_
   @@ copy ~from:"0" ~src:["/usr/local/bin/bwrap"] ~dst:"/usr/bin/bwrap" ()
   @@ copy ~from:"0" ~src:["/usr/bin/opam-2.0"] ~dst:"/usr/bin/opam-2.0" ()
   @@ copy ~from:"0" ~src:["/usr/bin/opam-2.1"] ~dst:"/usr/bin/opam-2.1" ()
+  @@ copy ~from:"0" ~src:["/usr/bin/opam-master"] ~dst:"/usr/bin/opam-2.2" () (* TODO: Change when opam 2.2 is branched *)
   @@ copy ~from:"0" ~src:["/usr/bin/opam-master"] ~dst:"/usr/bin/opam-dev" ()
   @@ run "ln /usr/bin/opam-2.0 /usr/bin/opam"
   @@ run
@@ -212,6 +215,7 @@ let zypper_opam2 ?(labels=[]) ?arch ~hash_opam_2_0 ~hash_opam_2_1 ~hash_opam_mas
   @@ copy ~from:"0" ~src:["/usr/local/bin/bwrap"] ~dst:"/usr/bin/bwrap" ()
   @@ copy ~from:"0" ~src:["/usr/bin/opam-2.0"] ~dst:"/usr/bin/opam-2.0" ()
   @@ copy ~from:"0" ~src:["/usr/bin/opam-2.1"] ~dst:"/usr/bin/opam-2.1" ()
+  @@ copy ~from:"0" ~src:["/usr/bin/opam-master"] ~dst:"/usr/bin/opam-2.2" () (* TODO: Change when opam 2.2 is branched *)
   @@ copy ~from:"0" ~src:["/usr/bin/opam-master"] ~dst:"/usr/bin/opam-dev" ()
   @@ run "ln /usr/bin/opam-2.0 /usr/bin/opam"
   @@ Linux.Zypper.add_user ~uid:1000 ~sudo:true "opam"
@@ -230,6 +234,7 @@ let pacman_opam2 ?(labels=[]) ?arch ~hash_opam_2_0 ~hash_opam_2_1 ~hash_opam_mas
   @@ from ~tag img
   @@ copy ~from:"0" ~src:["/usr/local/bin/opam-2.0"] ~dst:"/usr/bin/opam-2.0" ()
   @@ copy ~from:"0" ~src:["/usr/local/bin/opam-2.1"] ~dst:"/usr/bin/opam-2.1" ()
+  @@ copy ~from:"0" ~src:["/usr/local/bin/opam-master"] ~dst:"/usr/bin/opam-2.2" () (* TODO: Change when opam 2.2 is branched *)
   @@ copy ~from:"0" ~src:["/usr/local/bin/opam-master"] ~dst:"/usr/bin/opam-dev" ()
   @@ run "ln /usr/bin/opam-2.0 /usr/bin/opam"
   @@ Linux.Pacman.dev_packages ()
@@ -251,6 +256,7 @@ let cygwin_opam2 ?win10_revision ?(labels=[]) ?arch ~hash_opam_2_0 ~hash_opam_2_
   @@ from ~tag img
   @@ copy ~from:"0" ~src:["/usr/local/bin/opam-2.0"] ~dst:"/usr/bin/opam-2.0" ()
   @@ copy ~from:"0" ~src:["/usr/local/bin/opam-2.1"] ~dst:"/usr/bin/opam-2.1" ()
+  @@ copy ~from:"0" ~src:["/usr/local/bin/opam-master"] ~dst:"/usr/bin/opam-2.2" () (* TODO: Change when opam 2.2 is branched *)
   @@ copy ~from:"0" ~src:["/usr/local/bin/opam-master"] ~dst:"/usr/bin/opam-dev" ()
   @@ run "ln /usr/bin/opam-2.0 /usr/bin/opam"
   @@ Windows.Cygwin.(setup ~cyg ~extra:(cygwin_packages ()) ())

--- a/src-opam/dockerfile_opam.ml
+++ b/src-opam/dockerfile_opam.ml
@@ -163,7 +163,7 @@ let install_opams ?prefix f opam_branches =
 let copy_opams ~src ~dst opam_branches =
   List.fold_left (fun acc {branch; public_name; aliases; _} ->
       acc @@
-      copy ~from:"0" ~src:[src^branch] ~dst:(dst^public_name) () @@@
+      copy ~from:"0" ~src:[src^"/opam-"^branch] ~dst:(dst^"/"^public_name) () @@@
       List.map (fun alias -> run "ln %s/%s %s/%s" dst public_name dst alias) aliases
     ) empty opam_branches
 

--- a/src-opam/dockerfile_opam.ml
+++ b/src-opam/dockerfile_opam.ml
@@ -148,8 +148,8 @@ let create_opam_branches opam_hashes =
       branch = "master";
       hash = opam_master_hash;
       enable_0install_solver = true;
-      public_name = "opam-2.2"; (* TODO: Change when opam 2.2 is branched *)
-      aliases = ["opam-dev"];
+      public_name = "opam-dev";
+      aliases = ["opam-2.2"]; (* TODO: Remove/update when opam 2.2 is branched *)
     };
   ]
 

--- a/src-opam/dockerfile_opam.mli
+++ b/src-opam/dockerfile_opam.mli
@@ -54,8 +54,9 @@ val gen_opam2_distro :
   opam_hashes:opam_hashes ->
   Dockerfile_distro.t
   -> string * Dockerfile.t
-(** [gen_opam2_distro ~hash_opam_2_0 ~hash_opam_2_1 ~hash_opam_master d] will generate a Dockerfile
-   for Linux distribution [d] with opam 2.0 and opam 2.1, per hash given in parameter.
+(** [gen_opam2_distro ~opam_hashes d] will generate a Dockerfile
+   for Linux distribution [d] with opam 2.0, opam 2.1, opam 2.2 and opam master,
+   per hash given in parameter.
    @return a tuple of the Docker tag and the Dockerfile.
    If [clone_opam_repo] is true (the default) then the Dockerfile will also git
    clone the official opam-repository into [/home/opam/opam-repository].

--- a/src-opam/dockerfile_opam.mli
+++ b/src-opam/dockerfile_opam.mli
@@ -39,15 +39,19 @@ val install_opam_from_source : ?add_default_link:bool ->
     If [enable_0install_solver] is true (false by default), then the [builtin-0install]
     solver should be accessible in the resulting opam binary. *)
 
+type opam_hashes = {
+  opam_2_0_hash : string;
+  opam_2_1_hash : string;
+  opam_master_hash : string;
+}
+
 val gen_opam2_distro :
   ?win10_revision:Dockerfile_distro.win10_lcu ->
   ?winget:string ->
   ?clone_opam_repo:bool ->
   ?arch:Ocaml_version.arch ->
   ?labels:(string * string) list ->
-  hash_opam_2_0:string ->
-  hash_opam_2_1:string ->
-  hash_opam_master:string ->
+  opam_hashes:opam_hashes ->
   Dockerfile_distro.t
   -> string * Dockerfile.t
 (** [gen_opam2_distro ~hash_opam_2_0 ~hash_opam_2_1 ~hash_opam_master d] will generate a Dockerfile

--- a/src-opam/dockerfile_opam.mli
+++ b/src-opam/dockerfile_opam.mli
@@ -47,9 +47,10 @@ val gen_opam2_distro :
   ?labels:(string * string) list ->
   hash_opam_2_0:string ->
   hash_opam_2_1:string ->
+  hash_opam_master:string ->
   Dockerfile_distro.t
   -> string * Dockerfile.t
-(** [gen_opam2_distro ~hash_opam_2_0 ~hash_opam_2_1 d] will generate a Dockerfile
+(** [gen_opam2_distro ~hash_opam_2_0 ~hash_opam_2_1 ~hash_opam_master d] will generate a Dockerfile
    for Linux distribution [d] with opam 2.0 and opam 2.1, per hash given in parameter.
    @return a tuple of the Docker tag and the Dockerfile.
    If [clone_opam_repo] is true (the default) then the Dockerfile will also git


### PR DESCRIPTION
To make it easy to test opam master regularly it would be really handy to have an `opam-dev` binary around in the docker images.