### PR TITLE
Install devtoolset-7 for RHEL 7 derivatives

### DIFF
--- a/src-opam/dockerfile_opam.ml
+++ b/src-opam/dockerfile_opam.ml
@@ -221,10 +221,16 @@ let yum_opam2 ?(labels= []) ?arch ~yum_workaround ~enable_powertools ~opam_hashe
       @@ Linux.RPM.install "yum-plugin-ovl"
     else empty
   in
+  let repo_or_update, extra =
+    match distro with
+    | `CentOS `V7 -> Linux.RPM.install "centos-release-scl", Some "devtoolset-7"
+    | `OracleLinux `V7 -> Linux.RPM.install "oracle-softwarecollection-release-el7", Some "devtoolset-7"
+    | _ -> Linux.RPM.update, None
+  in
   header ?arch distro @@ label (("distro_style", "rpm") :: labels)
   @@ run "yum --version || dnf install -y yum"
   @@ workaround
-  @@ Linux.RPM.update
+  @@ repo_or_update
   @@ Linux.RPM.dev_packages ~extra:"which tar curl xz libcap-devel openssl" ()
   @@ Linux.Git.init ()
   @@ install_bubblewrap_from_source ()
@@ -233,7 +239,7 @@ let yum_opam2 ?(labels= []) ?arch ~yum_workaround ~enable_powertools ~opam_hashe
   @@ run "yum --version || dnf install -y yum"
   @@ workaround
   @@ Linux.RPM.update
-  @@ Linux.RPM.dev_packages ()
+  @@ Linux.RPM.dev_packages ?extra ()
   @@ (if enable_powertools then run "yum config-manager --set-enabled powertools" @@ Linux.RPM.update else empty)
   @@ copy ~from:"0" ~src:["/usr/local/bin/bwrap"] ~dst:"/usr/bin/bwrap" ()
   @@ copy_opams ~src:"/usr/bin" ~dst:"/usr/bin" opam_branches


### PR DESCRIPTION
RHEL 7 and clones (CentOS, Oracle Linux, etc.) have GCC 4.8 which is too old for multicore. It is possible to get GCC 7 via [RedHat Software Collections](https://www.softwarecollections.org/en/) which this PR starts to enable.

Accessing the commands needs some trickery via the `scl` command (`scl enable devtoolset-7 bash` gives you a shell with the appropriate tweaks - I haven't looked in enough detail to see if you can persist it).

There'd then be the question of whether to have _all_ CentOS 7 and Oracle Linux 7 images using GCC 7 (probably bad - better for the images for the older compilers to use the stock GCC, however old it is) or to build a separate opam image specifically for use by OCaml 5.00.0+ (more work, more space).

Anyway, this is what I'd done so far.