### PR TITLE
Unset the jobs variable from the opam config (faulty opam 2.0 behaviour)

### DIFF
--- a/src-opam/dockerfile_opam.ml
+++ b/src-opam/dockerfile_opam.ml
@@ -404,6 +404,7 @@ let all_ocaml_compilers hub_id arch distro =
     @@ sandbox
     @@ run "opam init -k git -a /home/opam/opam-repository --bare%s"
          (if os_family = `Windows then " --disable-sandboxing" else "")
+    @@ run "sed -i.bak -e '/^jobs: /d' /home/opam/.opam/config && rm /home/opam/.opam/config.bak"
     @@ compilers
     @@ run "opam switch %s" (OV.(to_string (with_patch OV.Releases.latest None)))
     @@ entrypoint_exec (pers @ ["opam"; "config"; "exec"; "--"])
@@ -445,6 +446,7 @@ let separate_ocaml_compilers hub_id arch distro =
            @@ sandbox
            @@ run "opam init -k git -a /home/opam/opam-repository --bare%s"
                 (if os_family = `Windows then "--disable-sandboxing" else "")
+           @@ run "sed -i.bak -e '/^jobs: /d' /home/opam/.opam/config && rm /home/opam/.opam/config.bak"
            @@ add_remote
            @@ variants
            @@ run "opam switch %s" default_switch_name


### PR DESCRIPTION
opam 2.0 by default stores the number of cores of the current machine. While not too much of a big deal for users, this is extremely bad for the base images where the number stored will be around 72 but these can be used on any other machines.

This might help fighting the IO overload on the cluster.