### PR TITLE
Use opam2 branch when pulling from opam-repository-mingw

### DIFF
--- a/src-opam/dockerfile_opam.ml
+++ b/src-opam/dockerfile_opam.ml
@@ -400,7 +400,11 @@ let all_ocaml_compilers hub_id arch distro =
       | `Windows | `Cygwin -> empty
     in
     header ~arch ~tag:(Printf.sprintf "%s-opam" distro_tag) ~img:hub_id distro
-    @@ workdir "/home/opam/opam-repository" @@ run "git pull origin master"
+    @@ workdir "/home/opam/opam-repository"
+    @@ run "git pull origin %s"
+         (match os_family with
+          | `Linux | `Cygwin -> "master"
+          | `Windows -> "opam2")
     @@ sandbox
     @@ run "opam init -k git -a /home/opam/opam-repository --bare%s"
          (if os_family = `Windows then " --disable-sandboxing" else "")


### PR DESCRIPTION
There seem to be no users of `all_ocaml_compilers` in all the pipelines I've examined, which explains why this had not been caught before.