### PR TITLE
5.0 alpha release readiness

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 v8.0.0 unreleased
 -----------------
 
+- Ubuntu LTS and current release is 22.04 (@dra27 #97)
 - When compiling opam, build OCaml once using `make compiler` on the master
   branch of opam and then share this compiler with the release branches.
   Simultaneously circumvents the `sigaltstack` problems with OCaml < 4.13 on new

--- a/src-opam/dockerfile_distro.ml
+++ b/src-opam/dockerfile_distro.ml
@@ -290,8 +290,8 @@ let resolve_alias (d:t) : distro =
   | `Fedora `Latest -> `Fedora `V35
   | `OracleLinux `Latest -> `OracleLinux `V8
   | `OpenSUSE `Latest -> `OpenSUSE `V15_3
-  | `Ubuntu `Latest -> `Ubuntu `V21_10
-  | `Ubuntu `LTS -> `Ubuntu `V20_04
+  | `Ubuntu `Latest -> `Ubuntu `V22_04
+  | `Ubuntu `LTS -> `Ubuntu `V22_04
   | `Cygwin (#win10_ltsc as v) -> `Cygwin (resolve_ltsc v)
   | `Windows (cc, (#win10_ltsc as v)) -> `Windows (cc, resolve_ltsc v)
   | `Alpine (`V3_3 | `V3_4 | `V3_5 | `V3_6 | `V3_7 | `V3_8 | `V3_9 | `V3_10 | `V3_11 | `V3_12 | `V3_13 | `V3_14 | `V3_15)

--- a/src-opam/dockerfile_distro.ml
+++ b/src-opam/dockerfile_distro.ml
@@ -361,9 +361,7 @@ let distro_arches ov (d:t) =
   | `Debian `V10, ov when OV.(compare Releases.v4_02_0 ov) = -1 -> [ `I386; `X86_64; `Aarch64; `Aarch32]
   | `Debian `V9, ov when OV.(compare Releases.v4_03_0 ov) = -1 -> [ `I386; `X86_64; `Aarch64; `Aarch32 ]
   | `Alpine (`V3_6 | `V3_7 | `V3_8 | `V3_9 | `V3_10 | `V3_11 | `V3_12 | `V3_13 | `V3_14 | `V3_15), ov when OV.(compare Releases.v4_05_0 ov) = -1 -> [ `X86_64; `Aarch64 ]
-  (* 2022-01-24: ppc64le seems to be broken on Jammy at the moment? *)
-  | `Ubuntu `V22_04, ov when OV.(compare Releases.v4_05_0 ov) = -1  -> [ `X86_64; `Aarch64]
-  | `Ubuntu (`V18_04|`V20_04|`V20_10|`V21_04|`V21_10), ov when OV.(compare Releases.v4_05_0 ov) = -1  -> [ `X86_64; `Aarch64; `Ppc64le ]
+  | `Ubuntu (`V18_04|`V20_04|`V20_10|`V21_04|`V21_10|`V22_04), ov when OV.(compare Releases.v4_05_0 ov) = -1  -> [ `X86_64; `Aarch64; `Ppc64le ]
   | `Fedora (`V33|`V34|`V35), ov when OV.(compare Releases.v4_08_0 ov) = -1  -> [ `X86_64; `Aarch64 ]
   (* 2021-04-19: should be 4.03 but there's a linking failure until 4.06. *)
   | `Windows (`Msvc, _), ov when OV.(compare Releases.v4_06_0 ov) = 1 -> []

--- a/src-opam/dockerfile_distro.ml
+++ b/src-opam/dockerfile_distro.ml
@@ -354,7 +354,6 @@ let distro_arches ov (d:t) =
   match resolve_alias d, ov with
   | `Windows (`Msvc, _), ov when OV.major ov >= 5 -> []
   | (`CentOS (`V6|`V7)|`OracleLinux `V7), ov when OV.major ov >= 5 -> []
-  | _, ov when OV.major ov >= 5 -> [ `X86_64 ]
   | `Debian `V11, ov when OV.(compare Releases.v4_03_0 ov) = -1 -> [ `I386; `X86_64; `Aarch64; `Aarch32; `Ppc64le; `S390x ]
   | `Debian `V11, ov when OV.(compare Releases.v4_02_0 ov) = -1 -> [ `I386; `X86_64; `Aarch64; `Aarch32]
   | `Debian `V10, ov when OV.(compare Releases.v4_03_0 ov) = -1 -> [ `I386; `X86_64; `Aarch64; `Aarch32; `Ppc64le; `S390x ]


### PR DESCRIPTION
- Ubuntu current release is 22.04 (and ppc64 is working again)
- Re-enable all the architectures for 5.0, since they all at least work in bytecode