### PR TITLE
Remove pin-depends from dockerfile-opam

### DIFF
--- a/dockerfile-opam.opam
+++ b/dockerfile-opam.opam
@@ -28,9 +28,6 @@ depends: [
   "sexplib"
   "fmt"
 ]
-pin-depends: [
-  [ "ocaml-version.dev" "git+https://github.com/mtelvers/ocaml-version#fb3b6e449611c36ad524daf219c3b14f181d667b" ]
-]
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]


### PR DESCRIPTION
This reverts commit e867243b3629dc3a3d97f1fd720171a39845f3c4 - it can be merged when there's a release of ocaml-version to opam-repository including https://github.com/ocurrent/ocaml-version/pull/49.