### PR TITLE
Adopt the OCaml Code of Conduct

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@ unreleased
 - Add newlines in some cases for better formatting.
   (@MisterDA #161, review by @benmandrew)
 - Various LCU Updates. (@mtelvers #160)
+- Adopt the OCaml Code of Conduct (@rikusilvola #177)
 
 v8.2.1 2023-04-07 Paris
 -----------------------

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,16 @@
+# Code of Conduct
+
+This project has adopted the [OCaml Code of Conduct](https://github.com/ocaml/code-of-conduct/blob/main/CODE_OF_CONDUCT.md).
+
+# Enforcement
+
+This project follows the OCaml Code of Conduct [enforcement policy](https://github.com/ocaml/code-of-conduct/blob/main/CODE_OF_CONDUCT.md#enforcement).
+
+To report any violations, please contact:
+
+* Antonin Décimo <antonin [at] tarides [dot] com>
+* Anil Madhavapeddy <anil [at] recoil [dot] org>
+* David Allsopp <david.allsopp [at] metastack [dot] com>
+* Kate Deplaix <kit-ty-kate [at] outlook [dot] com>
+* Thomas Leonard <talex5 [at] gmail [dot] com>
+* Tim McGilchrist <timmcgil [at] gmail [dot] com>


### PR DESCRIPTION
The OCaml Code of Conduct can be found in [ocaml/code-of-conduct](https://github.com/ocaml/code-of-conduct) and has been discussed [in this Discourse thread](https://discuss.ocaml.org/t/ocaml-community-code-of-conduct/10494).

We propose adopting it for ocurrent/ocaml-dockerfile as well.

cc @MisterDA @tmcgilchrist