### PR TITLE
Escape newlines in generated Dockerfiles

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 unreleased
 ----------
 
+- Escape newlines. (@MisterDA #192 #194, reported by @kit-ty-kate)
 - Add Ubuntu 23.10. (@MisterDA #189)
 - Deprecate Ubuntu 22.10 it is now EOL. (@tmcgilchrist #184).
 - Support `--start-interval` in `HEALTCHECK` Dockerfile instruction.

--- a/src/dockerfile.ml
+++ b/src/dockerfile.ml
@@ -200,10 +200,12 @@ let json_array_of_list sl =
 
 let string_of_shell_or_exec ~escape (t : shell_or_exec) =
   match t with
-  | `Shell s -> s
+  | `Shell s -> escape_string ~char_to_escape:'\n' ~escape s
   | `Shells [] -> ""
-  | `Shells [ s ] -> s
-  | `Shells l -> String.concat (" && " ^ String.make 1 escape ^ "\n  ") l
+  | `Shells [ s ] -> escape_string ~char_to_escape:'\n' ~escape s
+  | `Shells l ->
+      List.map (escape_string ~char_to_escape:'\n' ~escape) l
+      |> String.concat (" && " ^ String.make 1 escape ^ "\n  ")
   | `Exec sl -> json_array_of_list sl
 
 let quote_env_var = escape_string ~char_to_escape:'"'

--- a/test/dockerfile.ml
+++ b/test/dockerfile.ml
@@ -108,6 +108,16 @@ RUN script
   Alcotest.(check' string) ~msg:"complete" ~expected ~actual;
   ()
 
+let test_issue_192 () =
+  let open Dockerfile in
+  let actual = from "alpine" @@ run "ls\n/" |> string_of_t
+  and expected = {|FROM alpine
+RUN ls\
+/
+|} in
+  Alcotest.(check' string) ~msg:"escape newlines" ~expected ~actual;
+  ()
+
 let () =
   Alcotest.(
     run "test"
@@ -118,5 +128,6 @@ let () =
               test_string_of_t_formatting_simple_image;
             test_case "string_of_t" `Quick
               test_string_of_t_formatting_multiple_images;
+            test_case "test_issue_192" `Quick test_issue_192;
           ] );
       ])


### PR DESCRIPTION
Are there other places where newlines should be escaped? Everywhere, maybe?
Fix #192.