### PR TITLE
Cache distribution package downloads with BuildKit cache mounts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@ unreleased
 ----------
 
 - Add Alpine 3.21, deprecate Alpine 3.20. (@MisterDA, #225)
+- Cache packages downloads for Apt (Debian, Ubuntu) and pacman (Arch
+  Linux) based distributions using BuildKit cache mounts.
+  (@MisterDA, #224)
 
 v8.2.4 2024-11-18
 -----------------

--- a/src-opam/linux.mli
+++ b/src-opam/linux.mli
@@ -62,11 +62,12 @@ end
 module Apt : sig
   val update : t
   (** [update] will run [apt-get update && apt-get upgrade] non-interactively.
-  *)
+      Requires [syntax=docker/dockerfile:1]. *)
 
   val install : ('a, unit, string, t) format4 -> 'a
   (** [install fmt] will [apt-get update && apt-get install] the packages
-      specified by the [fmt] format string. *)
+      specified by the [fmt] format string. Requires
+      [syntax=docker/dockerfile:1]. *)
 
   val add_user : ?uid:int -> ?gid:int -> ?sudo:bool -> string -> t
   (** [add_user username] will install a new user with name [username] and a
@@ -150,11 +151,12 @@ end
 (** Rules for Pacman-based distributions such as Archlinux *)
 module Pacman : sig
   val update : t
-  (** [update] will run [pacman -Syu] non-interactively. *)
+  (** [update] will run [pacman -Syu] non-interactively. Requires
+      [syntax=docker/dockerfile:1]. *)
 
   val install : ('a, unit, string, t) format4 -> 'a
   (** [install fmt] will [pacman -Syu] the packages specified by the [fmt]
-      format string. *)
+      format string. Requires [syntax=docker/dockerfile:1]. *)
 
   val add_user : ?uid:int -> ?gid:int -> ?sudo:bool -> string -> t
   (** [add_user username] will install a new user with name [username] and a


### PR DESCRIPTION
I think sharing the package cache could make docker builds more efficient, but I'm also worried that parallel jobs could compete for the cache as it is exclusive (`locked`). Alternatively, it could be made `private` (creates a new mount if there are multiple writers), see [`RUN --mount=type=cache`](https://docs.docker.com/reference/dockerfile/#run---mounttypecache).

The code comes from an example in the Docker docs [Example: cache apt packages](https://docs.docker.com/reference/dockerfile/#example-cache-apt-packages):

```dockerfile
# syntax=docker/dockerfile:1
FROM ubuntu
RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
  --mount=type=cache,target=/var/lib/apt,sharing=locked \
  apt update && apt-get --no-install-recommends install -y gcc
```

> Apt needs exclusive access to its data, so the caches use the option `sharing=locked`, which will make sure multiple parallel builds using the same cache mount will wait for each other and not access the same cache files at the same time. You could also use `sharing=private` if you prefer to have each build create another cache directory in this case.