### PR TITLE
remove opam 2.0 support

### DIFF
--- a/src-opam/opam.ml
+++ b/src-opam/opam.ml
@@ -235,7 +235,7 @@ let create_opam_branches opam_hashes =
         enable_0install_solver = true;
         with_vendored_deps = false;
         public_name = "opam-2.1";
-        aliases = [];
+        aliases = ["opam"];
       };
       {
         branch = "2.2";

--- a/src-opam/opam.ml
+++ b/src-opam/opam.ml
@@ -189,7 +189,6 @@ let header ?arch ?maintainer ?img ?tag d =
   @@ from ?arch ?maintainer ?img ?tag d
 
 type opam_hashes = {
-  opam_2_0_hash : string;
   opam_2_1_hash : string;
   opam_2_2_hash : string;
   opam_2_3_hash : string;
@@ -219,7 +218,6 @@ let opam_master_branch opam_master_hash =
 
 let create_opam_branches opam_hashes =
   let {
-    opam_2_0_hash;
     opam_2_1_hash;
     opam_2_2_hash;
     opam_2_3_hash;
@@ -231,15 +229,6 @@ let create_opam_branches opam_hashes =
   in
   ( opam_master_hash,
     [
-      {
-        branch = "2.0";
-        hash = opam_2_0_hash;
-        enable_0install_solver = false;
-        with_vendored_deps = false;
-        public_name = "opam-2.0";
-        aliases = [ "opam" ];
-        (* Default *)
-      };
       {
         branch = "2.1";
         hash = opam_2_1_hash;

--- a/src-opam/opam.ml
+++ b/src-opam/opam.ml
@@ -235,7 +235,7 @@ let create_opam_branches opam_hashes =
         enable_0install_solver = true;
         with_vendored_deps = false;
         public_name = "opam-2.1";
-        aliases = ["opam"];
+        aliases = [ "opam" ];
       };
       {
         branch = "2.2";

--- a/src-opam/opam.mli
+++ b/src-opam/opam.mli
@@ -42,7 +42,6 @@ val install_opam_from_source :
     Configure opam build [with_vendored_deps]. Required for opam 2.2. *)
 
 type opam_hashes = {
-  opam_2_0_hash : string;
   opam_2_1_hash : string;
   opam_2_2_hash : string;
   opam_2_3_hash : string;


### PR DESCRIPTION
This leaves the 0install solver used by everything, but I'm leaving the option there for now to avoid interface breakage

See https://discuss.ocaml.org/t/proposal-make-the-minimum-tested-opam-2-1-and-higher/17736 for the discussion around this