### PR TITLE
Add tar to openSUSE dev packages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+unreleased
+----------
+
+- Add `tar` to the openSUSE/SLES dev package list; the Leap base image
+  no longer ships it (@mtelvers)
+
 v8.3.6 2026-04-23
 -----------------
 

--- a/src-opam/linux.ml
+++ b/src-opam/linux.ml
@@ -212,7 +212,7 @@ module Zypper = struct
     install "-t pattern devel_C_C++"
     @@ install
          "sudo git unzip curl gcc-c++ libcap-devel xz libX11-devel bzip2 which \
-          rsync gzip openssl%s"
+          rsync gzip openssl tar%s"
          (match extra with None -> "" | Some x -> " " ^ x)
 
   let ocaml_depexts v =


### PR DESCRIPTION
The openSUSE Leap 15.6 base image no longer ships `tar`, which causes `bootstrap-ocaml.sh` to fail when building opam from source. Add `tar` to the Zypper dev package list.