### PR TITLE
linux: add libzstd dev files correctly as done for debian.

### DIFF
--- a/src-opam/linux.ml
+++ b/src-opam/linux.ml
@@ -57,7 +57,7 @@ module RPM = struct
 
   let ocaml_depexts v =
     if Ocaml_version.compare v Ocaml_version.Releases.v5_1_0 >= 0 then
-      Some "zstd"
+      Some "libzstd-devel"
     else None
 
   let add_user ?uid ?gid ?(sudo = false) username =
@@ -154,7 +154,7 @@ module Apk = struct
 
   let ocaml_depexts v =
     if Ocaml_version.compare v Ocaml_version.Releases.v5_1_0 >= 0 then
-      Some "zstd"
+      Some "zstd-dev"
     else None
 
   let add_user ?uid ?gid ?(sudo = false) username =
@@ -217,7 +217,7 @@ module Zypper = struct
 
   let ocaml_depexts v =
     if Ocaml_version.compare v Ocaml_version.Releases.v5_1_0 >= 0 then
-      Some "zstd"
+      Some "libzstd-devel"
     else None
 
   let add_user ?uid ?gid ?(sudo = false) username =


### PR DESCRIPTION
Unclear if the default should be to use libzstd. The current state is that Debian correctly adds the libzstd dev file, whereas Alpine and others do not.

6a6d0fa added the OCaml 5.1+ zstd `libzstd-dev` on apt but plain `zstd` everywhere else. That package is CLI-only on alpine/fedora/rhel/suse, so configure silently disables compression and switches come out ~90MB bigger than on debian (.cmt 91MB vs 33MB on alpine). Arch's `zstd` ships headers, left as-is.

Used opus-4.8 