### PR TITLE
dockerfile: render a tmpfs mount as type=tmpfs

### DIFF
--- a/src/dockerfile.ml
+++ b/src/dockerfile.ml
@@ -335,7 +335,7 @@ let string_of_mount { typ } =
         @ optional_int "uid" uid @ optional_int "gid" gid)
   | `Tmpfs { target; size } ->
       String.concat ","
-        ([ "--mount=type=bind" ]
+        ([ "--mount=type=tmpfs" ]
         @ [ sprintf "target=%s" target ]
         @ optional_int "size" size)
   | `Ssh m | `Secret m ->


### PR DESCRIPTION
`string_of_mount`'s `Tmpfs` arm emitted `--mount=type=bind`, so a tmpfs mount rendered as a bind mount. Use `type=tmpfs`; the existing `size` option already emits a valid `size=N`.