### PR TITLE
Disable detached git maintenance in the base images

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,15 @@
+unreleased
+----------
+
+- Set `gc.autoDetach false` in the global git configuration of the base
+  images. `git fetch` spawns a detached `git maintenance run --auto`, and
+  since Git 2.55 that background run takes a lock file inside
+  `.git/objects`. The resulting change to the directory makes tar exit 1
+  with "file changed as we read it" as opam packs the repository it has
+  just fetched, so `opam repo add <git url>` fails on the distributions
+  now shipping Git 2.55: openSUSE Tumbleweed, Fedora 44 and Debian
+  unstable (@mtelvers)
+
 v8.4.1 2026-06-10
 -----------------
 

--- a/src-opam/linux.ml
+++ b/src-opam/linux.ml
@@ -25,6 +25,19 @@ module Git = struct
   let init ?(name = "Docker") ?(email = "docker@example.com") () =
     run "git config --global user.email %S" email
     @@ run "git config --global user.name %S" name
+    (* "git fetch" ends by spawning "git maintenance run --auto --detach",
+       which carries on running after fetch itself has returned.  Since Git
+       2.55 that background run creates and then removes a lock file inside
+       .git/objects.  That changes the directory underneath opam as it tars
+       up the repository it has just fetched, so GNU tar exits 1 with "file
+       changed as we read it" and "opam repo add" fails.
+
+       Turning off autoDetach runs the maintenance in the foreground, so the
+       repository is quiescent by the time opam reads it.  We set
+       gc.autoDetach rather than maintenance.autoDetach because the latter
+       falls back to it, and it is also understood by older versions of
+       git. *)
+    @@ run "git config --global gc.autoDetach false"
 end
 
 let sudo_nopasswd = "ALL=(ALL:ALL) NOPASSWD:ALL"

--- a/src-opam/windows.ml
+++ b/src-opam/windows.ml
@@ -139,6 +139,9 @@ let git_init ~name ~email ~repos =
     (sprintf "git config --global user.email '%s'" email
     :: sprintf "git config --global user.name '%s'" name
     :: "git config --system core.longpaths true"
+       (* See the comment in Linux.Git.init: a detached auto maintenance races
+       opam's tarring of the repository it has just fetched. *)
+    :: "git config --global gc.autoDetach false"
     :: List.map
          (fun repo ->
            sprintf "git config --global --add safe.directory %s" repo)


### PR DESCRIPTION
`opam repo add <git url>` fails everywhere git 2.55 has landed — openSUSE Tumbleweed, Fedora 44, Debian unstable:

```
/usr/bin/tar: ocaml-patches-overlay/.git/objects: file changed as we read it
```

`git fetch` spawns `git maintenance run --auto --detach`, which keeps running after fetch returns. That's not new, but in 2.55 the background run takes a lock at `.git/objects/maintenance.lock`, and creating/removing it changes the `.git/objects` directory while opam is tarring the repo up. tar then exits 1.

From the [2.55 release notes](https://github.com/git/git/blob/v2.55.0/Documentation/RelNotes/2.55.0.adoc):

> "git maintenance" that goes background did not use the lockfile to prevent multiple maintenance processes from running at the same time, which has been corrected.

`gc.autoDetach false` makes the maintenance run in the foreground, so the repo is quiet by the time opam reads it. Fixes tumbleweed, fedora-44 and debian-unstable; 3/3 fetch+tar cycles fail before and pass after. Set `gc.autoDetach` rather than `maintenance.autoDetach` because [the latter falls back to it](https://git-scm.com/docs/git-maintenance) and old git understands it too (checked on debian-11, git 2.30.2).

Also added to the Cygwin `git_init`, which will hit this whenever Cygwin's git catches up.

This is a workaround in our images for ocaml/opam#7031, which is the same race on the opam side.